### PR TITLE
fix: 修复构建错误

### DIFF
--- a/dde-network-dialog/dockpopupwindow.cpp
+++ b/dde-network-dialog/dockpopupwindow.cpp
@@ -31,6 +31,7 @@
 #include <QAccessible>
 #include <QAccessibleEvent>
 #include <QString>
+#include <QPainterPath>
 
 #include <iostream>
 


### PR DESCRIPTION
/build/dde-network-core-1.0.32.2/dde-network-dialog/dockpopupwindow.cpp:243:22: error: aggregate 'QPainterPath path' has incomplete type and cannot be defined
         QPainterPath path;
                      ^~~~