### PR TITLE
fix: 初始化网络连接编辑界面时需要向DBUS注册NMVariantMapMap数据类型

### DIFF
--- a/dcc-network-plugin/connectioneditpage.cpp
+++ b/dcc-network-plugin/connectioneditpage.cpp
@@ -67,6 +67,7 @@ ConnectionEditPage::ConnectionEditPage(ConnectionType connType, const QString &d
     , m_connType(static_cast<ConnectionSettings::ConnectionType>(connType))
     , m_isHotSpot(isHotSpot)
 {
+    qDBusRegisterMetaType<NMVariantMapMap>();
     DevicePath = devPath;
 
     initUI();


### PR DESCRIPTION
没有向DBUS注册NMVariantMapMap数据类型，在调用接口时无法解析此类型类所，导致程序崩溃

Log: 修复点击编辑网络连接时控制中心崩溃问题
Task: https://pms.uniontech.com/task-view-175119.html
Influence: 正常编辑网络连接
Change-Id: I9b8f6e0ef4498b60f3d943b33ad4da23bcf3e648