### PR TITLE
fix: 修复“使用LZO压缩”未识别“comp-lzo adaptive”的问题

### DIFF
--- a/dcc-network-plugin/sections/vpn/vpnadvopenvpnsection.cpp
+++ b/dcc-network-plugin/sections/vpn/vpnadvopenvpnsection.cpp
@@ -140,7 +140,7 @@ void VpnAdvOpenVPNSection::initUI()
     m_renegInterval->setVisible(m_renegIntervalSwitch->checked());
 
     m_compLZOSwitch->setTitle(tr("Use LZO Data Compression"));
-    m_compLZOSwitch->setChecked(m_dataMap.value("comp-lzo") == "yes");
+    m_compLZOSwitch->setChecked(m_dataMap.value("comp-lzo") == "yes" || m_dataMap.value("comp-lzo") == "adaptive");
 
     m_tcpProtoSwitch->setTitle(tr("Use TCP Connection"));
     m_tcpProtoSwitch->setChecked(m_dataMap.value("proto-tcp") == "yes");


### PR DESCRIPTION
从OpenVPN配置文件导入VPN时，如果该文件中有配置“comp-lzo”或“comp-lzo
adaptive”，导入后在图形界面中“使用LZO压缩”这一开关仍是关闭的状态。原因：代码中的判断条件是“comp-lzo”值为"yes"时才开启，未考虑值为“adaptive”的情况。

Log: 修复“使用LZO压缩”未识别“comp-lzo adaptive”的问题
Influence: 控制中心 - 网络 - VPN - VPN高级选项 - 使用LZO压缩