### PR TITLE
fix: 正在连接时允许修改连接信息

### DIFF
--- a/common-plugin/secretagent.cpp
+++ b/common-plugin/secretagent.cpp
@@ -183,7 +183,7 @@ void SecretAgent::dialogFinished()
 }
 
 void SecretAgent::readProcessOutput()
-{        
+{
     for (int i = 0; i < m_calls.size(); ++i) {
         SecretsRequest request = m_calls[i];
         if (request.type == SecretsRequest::GetSecrets && request.process == m_process) {
@@ -244,7 +244,7 @@ bool SecretAgent::processGetSecrets(SecretsRequest &request) const
     const bool requestNew = request.flags & RequestNew;
     const bool userRequested = request.flags & UserRequested;
     const bool allowInteraction = request.flags & AllowInteraction;
-    const bool isVpn = (setting->type() == NetworkManager::Setting::Vpn);    
+    const bool isVpn = (setting->type() == NetworkManager::Setting::Vpn);
 
     if (isVpn) {
         NetworkManager::VpnSetting::Ptr vpnSetting = connectionSettings->setting(NetworkManager::Setting::Vpn).dynamicCast<NetworkManager::VpnSetting>();
@@ -286,7 +286,7 @@ bool SecretAgent::processGetSecrets(SecretsRequest &request) const
     }
 
     if (requestNew || (allowInteraction && !setting->needSecrets(requestNew).isEmpty()) || (allowInteraction && userRequested)
-               || (isVpn && allowInteraction)) {        
+               || (isVpn && allowInteraction)) {
         DEBUG_PRINT << "process request secrets";
 
         // 只处理无线的
@@ -382,7 +382,7 @@ void SecretAgent::sendSecrets(const NMVariantMapMap &secrets, const QDBusMessage
 {
     QDBusMessage reply;
     reply = message.createReply(QVariant::fromValue(secrets));
-    if (!QDBusConnection::systemBus().send(reply)) {        
+    if (!QDBusConnection::systemBus().send(reply)) {
         qWarning() << "Failed put the secret into the queue";
     }
 }

--- a/dcc-network-plugin/connectioneditpage.h
+++ b/dcc-network-plugin/connectioneditpage.h
@@ -30,6 +30,7 @@
 #include <widgets/contentwidget.h>
 
 #include <networkmanagerqt/connection.h>
+#include <networkmanagerqt/activeconnection.h>
 #include <networkmanagerqt/connectionsettings.h>
 
 namespace dcc {
@@ -77,6 +78,7 @@ public:
     static void setFrameProxy(FrameProxyInterface *frame);
     void setButtonTupleEnable(bool enable);
     void setLeftButtonEnable(bool enable);
+    void initHeaderButtons();
 
 Q_SIGNALS:
     void requestNextPage(ContentWidget *const page);
@@ -100,13 +102,12 @@ protected:
 
 private:
     void initUI();
-    void initHeaderButtons();
     void initConnection();
     void initConnectionSecrets();
     void saveConnSettings();
     void updateConnection();
     void createConnSettings();
-    bool isConnected();
+    const NetworkManager::ActiveConnection::State ConnectedState();
 
     NMVariantMapMap secretsMapMapBySettingType(Setting::SettingType settingType);
     // T means a Setting subclass, like WirelessSecuritySetting

--- a/dcc-network-plugin/connectionpageitem.cpp
+++ b/dcc-network-plugin/connectionpageitem.cpp
@@ -14,8 +14,8 @@ ConnectionPageItem::ConnectionPageItem(QWidget *widget, DListView *listView, Con
     : DStandardItem()
     , m_loadingIndicator(new DSpinner)
     , m_parentView(listView)
-    , m_editAction(new DViewItemAction(Qt::AlignmentFlag::AlignCenter, QSize(), QSize(), true))
-    , m_loadingAction(new DViewItemAction(Qt::AlignmentFlag::AlignRight, QSize(), QSize(), true))
+    , m_editAction(new DViewItemAction(Qt::AlignmentFlag::AlignVCenter, QSize(), QSize(), true))
+    , m_loadingAction(new DViewItemAction(Qt::AlignmentFlag::AlignVCenter, QSize(), QSize(), true))
     , m_itemData(nullptr)
     , m_connection(connection)
 {
@@ -24,17 +24,17 @@ ConnectionPageItem::ConnectionPageItem(QWidget *widget, DListView *listView, Con
     m_loadingIndicator->setFixedSize(20, 20);
     m_loadingIndicator->setParent(m_parentView->viewport());
 
+    m_loadingAction->setWidget(m_loadingIndicator);
+    m_loadingAction->setVisible(false);
+
     QStyleOption opt;
     m_editAction->setIcon(DStyleHelper(widget->style()).standardIcon(DStyle::SP_ArrowEnter, &opt, nullptr));
     m_editAction->setClickAreaMargins(ArrowEnterClickMargin);
 
-    m_loadingAction->setWidget(m_loadingIndicator);
-
-    setActionList(Qt::Edge::RightEdge, { m_editAction, m_loadingAction });
+    setActionList(Qt::Edge::RightEdge, { m_loadingAction, m_editAction });
 
     setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
 
-    m_loadingAction->setVisible(false);
     connect(m_loadingAction, &DViewItemAction::destroyed, this, [ this ] {
        this->m_loadingAction = nullptr;
     });
@@ -87,12 +87,9 @@ void ConnectionPageItem::setConnectionStatus(const ConnectionStatus &status)
 void ConnectionPageItem::setLoading(const bool isLoading)
 {
     if (isLoading) {
-        m_editAction->setVisible(false);
         m_loadingIndicator->start();
         m_loadingAction->setVisible(true);
     } else {
-        m_editAction->setVisible(true);
-        //m_loadingIndicator->stop();
         m_loadingIndicator->setVisible(false);
         m_loadingAction->setVisible(false);
     }

--- a/dcc-network-plugin/hotspotpage.cpp
+++ b/dcc-network-plugin/hotspotpage.cpp
@@ -133,6 +133,11 @@ void HotspotDeviceWidget::addItems(const QList<HotspotItem *> &newItems)
         m_modelprofiles->appendRow(pageItem);
     }
     m_isClicked = false;
+
+    // 根据连接状态刷新按钮状态
+    if (!m_editPage.isNull()) {
+        m_editPage->initHeaderButtons();
+    }
 }
 
 void HotspotDeviceWidget::removeItems(const QList<HotspotItem *> &rmItems)
@@ -154,6 +159,11 @@ void HotspotDeviceWidget::updateItemStatus(const QList<HotspotItem *> &items)
             item->setText(hotspotItem->connection()->ssid());
             item->setConnectionStatus(hotspotItem->status());
         }
+    }
+
+    // 根据连接状态刷新按钮状态
+    if (!m_editPage.isNull()) {
+        m_editPage->initHeaderButtons();
     }
 }
 
@@ -237,6 +247,11 @@ void HotspotDeviceWidget::onSwitchToggled(const bool checked)
         }
         closeHotspot();
     }
+
+    // 根据连接状态刷新按钮状态
+    if (!m_editPage.isNull()) {
+        m_editPage->initHeaderButtons();
+    }
 }
 
 void HotspotDeviceWidget::onConnWidgetSelected(const QModelIndex &idx)
@@ -244,6 +259,11 @@ void HotspotDeviceWidget::onConnWidgetSelected(const QModelIndex &idx)
     const QString uuid = idx.data(UuidRole).toString();
     if (uuid.isEmpty())
         return;
+
+    // 正在编辑连接信息时，点击连接空白处切换编辑内容
+    if (!m_editPage.isNull() && m_editPage->connectionUuid() != uuid) {
+        onConnEditRequested(uuid);
+    }
 
     // 个人热点开启时才尝试激活连接
     if (m_hotspotSwitch->checked()) {

--- a/dcc-network-plugin/pppoepage.h
+++ b/dcc-network-plugin/pppoepage.h
@@ -79,6 +79,7 @@ private Q_SLOTS:
     void onConnectionListChanged();
     void onItemChanged(const QList<DSLItem *> &items);
     void onActiveConnectionChanged();
+    void onShowEditPage(const QString &devicePath, const QString &uuid);
 
 private:
     DListView *m_lvsettings;

--- a/dcc-network-plugin/vpnpage.h
+++ b/dcc-network-plugin/vpnpage.h
@@ -78,6 +78,8 @@ private Q_SLOTS:
     void importVPN();
     void createVPN();
     void changeVpnId();
+    void showEditPage(VPNItem *vpn);
+
 private:
     SwitchWidget *m_vpnSwitch;
 


### PR DESCRIPTION
1.网络连接过程中，“正在连接”的图标、显示在设置图标“>”左侧；
2.连接过程中，点击“>”进入设置页面：最上方显示【正在连接】、【删除】按钮，最下方显示【取消】、【保存】按钮；
3.连接过程中，【正在连接】按钮置灰、不可点击，连接成功后，显示为【断开连接】按钮、可以点击；【删除】、【取消】、【保存】沿用现有逻辑；
4.有线/无线/DSL/VPN/热点，需要统一修改
5.正在编辑连接信息时，点击其他连接时切换编辑界面内容到当前连接

Log: 修复连接过程中无法修改网络信息的问题
Bug: https://pms.uniontech.com/bug-view-151009.html
Influence: 连接过程中允许编辑连接信息，切换连接时切换编辑界面内容
Change-Id: Id9ac9eabd003bc8952aba13d2a99184e53f4a541