### PR TITLE
fix: 修复dde-network-core未指定CMAKE_INSTALL_PREFIX导致默认安装位置错误的问题、修改其他子项目安装路径为相对路径

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.7)
 
 project(dde-network-core)
 
+# Install settings
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "/usr")
+endif ()
+
 # 增加安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")

--- a/dde-network-dialog/CMakeLists.txt
+++ b/dde-network-dialog/CMakeLists.txt
@@ -59,6 +59,8 @@ target_link_libraries(${TARGET_NAME} PRIVATE
     ${Qt5Network_LIBRARIES}
 )
 
-install(TARGETS ${TARGET_NAME} DESTINATION /usr/bin)
+set(CMAKE_INSTALL_PREFIX "/usr")
+
+install(TARGETS ${TARGET_NAME} DESTINATION bin)
 # 安装 .qm 文件
-install(FILES ${QM_FILES} DESTINATION /usr/share/${TARGET_NAME}/translations)
+install(FILES ${QM_FILES} DESTINATION share/${TARGET_NAME}/translations)

--- a/dock-network-plugin/CMakeLists.txt
+++ b/dock-network-plugin/CMakeLists.txt
@@ -64,6 +64,8 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
     ${Qt5Network_LIBRARIES}
 )
 
-install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION /usr/lib/dde-dock/plugins/system-trays)
+set(CMAKE_INSTALL_PREFIX "/usr")
+
+install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION lib/dde-dock/plugins/system-trays)
 # 安装 .qm 文件
-install(FILES ${QM_FILES} DESTINATION /usr/share/${PLUGIN_NAME}/translations)
+install(FILES ${QM_FILES} DESTINATION share/${PLUGIN_NAME}/translations)

--- a/dss-network-plugin/CMakeLists.txt
+++ b/dss-network-plugin/CMakeLists.txt
@@ -63,7 +63,9 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
     ${Qt5Network_LIBRARIES}
 )
 
-install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION /lib/dde-session-shell/modules)
+set(CMAKE_INSTALL_PREFIX "/usr")
+
+install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION lib/dde-session-shell/modules)
 # 安装 .qm 文件
-install(FILES ${QM_FILES} DESTINATION /usr/share/${PLUGIN_NAME}/translations)
+install(FILES ${QM_FILES} DESTINATION share/${PLUGIN_NAME}/translations)
 install(FILES 10-network-manager.pkla DESTINATION /var/lib/polkit-1/localauthority/10-vendor.d)


### PR DESCRIPTION
在dde-network-core的CMakeLists.txt中指定CMAKE_INSTALL_PREFIX为“/usr”;
将子项目（dde-network-dialog、dock-network-plugin、dss-network-plugin）中以“/usr”开头的安装路径均修改为相对路径；


Log: 修复dde-network-core未指定CMAKE_INSTALL_PREFIX导致默认安装位置错误的问题，并修改其他子项目安装路径为相对路径