### PR TITLE
fix: 根据文件内容判断WIFI是否支持WPA3个人版安全协议

### DIFF
--- a/dcc-network-plugin/sections/secrethotspotsection.cpp
+++ b/dcc-network-plugin/sections/secrethotspotsection.cpp
@@ -133,17 +133,44 @@ void SecretHotspotSection::initStrMaps()
     KeyMgmtStrMap = {
         { tr("None"), WirelessSecuritySetting::KeyMgmt::WpaNone },
         { tr("WEP"), WirelessSecuritySetting::KeyMgmt::Wep },
-        { tr("WPA/WPA2 Personal"), WirelessSecuritySetting::KeyMgmt::WpaPsk },
-        { tr("WPA3 Personal"), WirelessSecuritySetting::KeyMgmt::WpaSae }
+        { tr("WPA/WPA2 Personal"), WirelessSecuritySetting::KeyMgmt::WpaPsk }
     };
+
+    bool enableWPA3 = true;
+    // 读取文件，根据内容判断热点是否支持WPA3个人协议  1103不支持 1105支持
+    // 若无此文件则默认支持
+    QFile file("/sys/hisys/wal/wifi_devices_info");
+    if (file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        QTextStream stream(&file);
+        while (!stream.atEnd()) {
+            QString line = stream.readLine();
+            if (line.isEmpty()) {
+                break;
+            }
+
+            QStringList value = line.split(":");
+            if (value.size() >= 2 && value.at(1).contains("1103")) {
+                enableWPA3 = false;
+                break;
+            }
+        }
+        file.close();
+    }
+
+    if (enableWPA3) {
+        KeyMgmtStrMap.insert(tr("WPA3 Personal"), WirelessSecuritySetting::KeyMgmt::WpaSae);
+    }
 }
 
 void SecretHotspotSection::initUI()
 {
     QComboBox *cb = m_keyMgmtChooser->comboBox();
     m_keyMgmtChooser->setTitle(tr("Security"));
-    for (auto keyMgmt : KeyMgmtList)
-        cb->addItem(KeyMgmtStrMap.key(keyMgmt), keyMgmt);
+    for (auto keyMgmt : KeyMgmtList) {
+        if (KeyMgmtStrMap.values().contains(keyMgmt)) {
+            cb->addItem(KeyMgmtStrMap.key(keyMgmt), keyMgmt);
+        }
+    }
 
     cb->setCurrentIndex(cb->findData(m_currentKeyMgmt));
 


### PR DESCRIPTION
根据/sys/hisys/wal/wifi_devices_info文件中Chip Type值判断WIFI是否支持WPA3个人版安全协议， 其中
1103不支持1105支持，若无此文件默认支持

Log: 修复PanguV不支持WPA3加密个人，热点安全允许设置成WPA3模式的问题
Bug: https://pms.uniontech.com/bug-view-151699.html
Influence: PanguV不支持WPA3加密个人
Change-Id: I5b8e1b086a53223111d84b006eca48c55c5776ab