### PR TITLE
fix: 修复网络面板位置异常和无法消失的问题

### DIFF
--- a/common-plugin/networkdialog.cpp
+++ b/common-plugin/networkdialog.cpp
@@ -97,6 +97,11 @@ void NetworkDialog::show()
     });
 }
 
+void NetworkDialog::setServerName(const QString &name)
+{
+    m_serverName = name;
+}
+
 void NetworkDialog::requestFocus()
 {
     for (QWidget *w : qApp->topLevelWidgets()) {

--- a/common-plugin/networkdialog.h
+++ b/common-plugin/networkdialog.h
@@ -59,6 +59,7 @@ public:
     bool isVisible() const;
     void setLocale(const QString &locale);
     void closeDialog();
+    void setServerName(const QString &name);
 
 private:
     void runProcess(bool show = true);

--- a/dock-network-plugin/networkplugin.cpp
+++ b/dock-network-plugin/networkplugin.cpp
@@ -68,6 +68,7 @@ void NetworkPlugin::init(PluginProxyInterface *proxyInter)
         return;
 
     m_networkDialog = new NetworkDialog(this);
+    m_networkDialog->setServerName("dde-network-dialog" + QString::number(getuid()) + "dock");
     m_networkHelper.reset(new NetworkPluginHelper(m_networkDialog));
     QDBusConnection::sessionBus().connect("com.deepin.dde.lockFront", "/com/deepin/dde/lockFront", "com.deepin.dde.lockFront", "Visible", this, SLOT(lockFrontVisible(bool)));
 

--- a/dss-network-plugin/network_module.cpp
+++ b/dss-network-plugin/network_module.cpp
@@ -61,6 +61,7 @@ NetworkModule::NetworkModule(QObject *parent)
     }
 
     m_networkDialog = new NetworkDialog(this);
+    m_networkDialog->setServerName("dde-network-dialog" + QString::number(getuid()) + "lock");
     m_networkDialog->setRunReason(NetworkDialog::Lock);
     m_networkHelper = new NetworkPluginHelper(m_networkDialog, this);
 


### PR DESCRIPTION
由于socket连接错误,导致网络面板状态和位置异常

Log: 修复网络面板位置异常和无法消失的问题
Bug: https://pms.uniontech.com/bug-view-151667.html
Bug: https://pms.uniontech.com/bug-view-151659.html
Influence: 网络面板
Change-Id: I10e889f670b368d42a79467b1e1ea6bbf26091be