### PR TITLE
fix: 设置网络列表窗口类型为Tool

### DIFF
--- a/dde-network-dialog/dockpopupwindow.cpp
+++ b/dde-network-dialog/dockpopupwindow.cpp
@@ -66,7 +66,7 @@ DockPopupWindow::DockPopupWindow(RunReason runReaseon, QWidget *parent)
         windowHandle()->setProperty("_d_dwayland_window-type", "override");
     } else {
         if (runReaseon == Lock || runReaseon == Greeter)
-            setWindowFlags(Qt::Popup | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
+            setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
         else
             setWindowFlags(Qt::Dialog | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
     }


### PR DESCRIPTION
设置网络列表窗口类型为Tool,密码框自动获取焦点

Log: 修复登录/锁屏界面点击加密WIFI时光标不在密码框的问题
Bug: https://pms.uniontech.com/bug-view-153215.html
Bug: https://pms.uniontech.com/bug-view-149739.html
Influence: 登录锁屏界面连接加密WIFI时，密码框自动获取焦点