### PR TITLE
fix: 修复打开网络面板后锁屏，网络面板没有自动隐藏的问题

### DIFF
--- a/dde-network-dialog/dockpopupwindow.cpp
+++ b/dde-network-dialog/dockpopupwindow.cpp
@@ -33,6 +33,7 @@
 #include <QAccessibleEvent>
 #include <QString>
 #include <QPainterPath>
+#include <DDBusSender>
 
 #include <iostream>
 
@@ -64,6 +65,7 @@ DockPopupWindow::DockPopupWindow(RunReason runReaseon, QWidget *parent)
         setWindowFlags(windowFlags() | Qt::Dialog | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
         setAttribute(Qt::WA_NativeWindow);
         windowHandle()->setProperty("_d_dwayland_window-type", "override");
+        QDBusConnection::sessionBus().connect("com.deepin.dde.lockFront", "/com/deepin/dde/lockFront", "com.deepin.dde.lockFront", "Visible", this, SLOT(lockFrontVisible(bool)));
     } else {
         if (runReaseon == Lock || runReaseon == Greeter)
             setWindowFlags(Qt::Tool | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
@@ -80,6 +82,13 @@ DockPopupWindow::DockPopupWindow(RunReason runReaseon, QWidget *parent)
 
     connect(m_wmHelper, &DWindowManagerHelper::hasCompositeChanged, this, &DockPopupWindow::compositeChanged);
     connect(m_regionInter, &DRegionMonitor::buttonPress, this, &DockPopupWindow::onGlobMouseRelease);
+}
+
+void DockPopupWindow::lockFrontVisible(bool visible)
+{
+    if (visible) {
+        closeDialog();
+    }
 }
 
 DockPopupWindow::~DockPopupWindow()

--- a/dde-network-dialog/dockpopupwindow.h
+++ b/dde-network-dialog/dockpopupwindow.h
@@ -78,6 +78,7 @@ protected:
 private slots:
     void compositeChanged();
     void ensureRaised();
+    void lockFrontVisible(bool visible);
 
 private:
     bool m_model;

--- a/dock-network-plugin/networkplugin.cpp
+++ b/dock-network-plugin/networkplugin.cpp
@@ -259,13 +259,11 @@ void NetworkPlugin::onDockPropertiesChanged(const QString &interfaceName, const 
         return;
     }
 
-    for (QVariantMap::const_iterator it = changedProperties.begin(); it != changedProperties.end(); ++it) {
-        if (it.key().toLatin1() == "FrontendWindowRect") {
-            // 延迟100ms处理,避免获取到的坐标有误(dock移动位置有动态效果，不加延时的话可能会获取动画中的位置)
-            QTimer::singleShot(100, this, [this] {
-                showNetworkDialog(m_trayIcon.data());
-                m_networkDialog->updateDialogPosition();
-            });
-        }
+    if (changedProperties.contains("FrontendWindowRect")) {
+        // 延迟100ms处理,避免获取到的坐标有误(dock移动位置有动态效果，不加延时的话可能会获取动画中的位置)
+        QTimer::singleShot(100, this, [this] {
+            showNetworkDialog(m_trayIcon.data());
+            m_networkDialog->updateDialogPosition();
+        });
     }
 }


### PR DESCRIPTION
锁屏界面层级改为最高，导致锁屏之后网络面板无法自动隐藏

Log: 修复打开网络面板后锁屏，网络面板无法隐藏的问题
Bug: https://pms.uniontech.com/bug-view-153771.html
Influence: 打开网络面板，然后锁屏
Change-Id: I1c559c79cbd548c619eb9615e6dd3dac06c6974a