### PR TITLE
fix: 修复无线络断开后无法自动回连的问题

### DIFF
--- a/src/realize/deviceinterrealize.cpp
+++ b/src/realize/deviceinterrealize.cpp
@@ -510,8 +510,14 @@ AccessPoints *WirelessDeviceInterRealize::activeAccessPoints() const
 }
 
 void WirelessDeviceInterRealize::disconnectNetwork()
-{
-    networkInter()->DisconnectDevice(QDBusObjectPath(path()));
+{    
+    // 使用DeactivateConnection而不是DisconnectDevice，是为了能在断开当前网络后仍能自动回连其他热点
+    WirelessConnection *wirelessConn = findConnectionByAccessPoint(activeAccessPoints());
+    if (!wirelessConn)
+        return;
+
+    const QString uuid = wirelessConn->connection()->uuid();
+    networkInter()->DeactivateConnection(uuid);
 }
 
 QList<WirelessConnection *> WirelessDeviceInterRealize::items() const

--- a/src/wirelessdevice.cpp
+++ b/src/wirelessdevice.cpp
@@ -72,6 +72,11 @@ bool WirelessDevice::hotspotEnabled() const
     return deviceRealize()->hotspotEnabled();
 }
 
+void WirelessDevice::disconnectNetwork()
+{
+    return deviceRealize()->disconnectNetwork();
+}
+
 void WirelessDevice::connectNetwork(const QString &ssid)
 {
     AccessPoints *apConnection = findAccessPoint(ssid);

--- a/src/wirelessdevice.h
+++ b/src/wirelessdevice.h
@@ -52,6 +52,7 @@ public:
     QList<WirelessConnection *> items() const;                      // 无线网络连接列表
     AccessPoints *activeAccessPoints() const;                       // 当前活动的无线连接
     bool hotspotEnabled() const;                                    // 是否开启热点
+    void disconnectNetwork();
 
 Q_SIGNALS:
     void networkAdded(QList<AccessPoints *>);                       // wlan新增网络


### PR DESCRIPTION
调用的方法错误，换成DeactivateConnection就可以了

Log: 修复无线络断开后无法自动回连的问题
Influence: 任务栏--无线网络，断开后自动回连
Bug: https://pms.uniontech.com/bug-view-146233.html
Change-Id: Ieb2483854164c373c9b88d28f0b56c8623d98d78