### PR TITLE
fix: 社区版锁屏界面可以使用alt+tag快捷键

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.user
 build/
+.cache/

--- a/dde-network-dialog/dockpopupwindow.cpp
+++ b/dde-network-dialog/dockpopupwindow.cpp
@@ -150,6 +150,10 @@ void DockPopupWindow::show(const int x, const int y)
 
 void DockPopupWindow::showEvent(QShowEvent *e)
 {
+    // 显示的时候主动去grab键盘（如果不主动抓取，在社区版上弹窗大概率没有抓取到键盘，可能跟qt的版本有关）
+    if (window() && window()->windowHandle()) {
+        window()->windowHandle()->setKeyboardGrabEnabled(true);
+    }
     DArrowRectangle::showEvent(e);
     QTimer::singleShot(1, this, &DockPopupWindow::ensureRaised);
 }


### PR DESCRIPTION
原因：社区版上popup属性弹窗大概率没有抓取到键盘，可能跟qt的版本或者时序有关。
解决方案：弹窗显示的时候主动抓取一下.
PS：在两个进程“取消”和“抓取”的间隙，快捷键是可以使用的，目前的方案只是降低了出现问题的概率；
要从根本上解决需要把网络弹窗合入到锁屏作为一个进程。

Log: 解决社区版锁屏界面可以使用alt+tag快捷键的问题
Bug: https://pms.uniontech.com/bug-view-147677.html
Influence: 锁屏可以使用alt+tag快捷键
Change-Id: I6068286e38b0d1327b67c3422eac9ee1fc07a491