### PR TITLE
fix: 热插拔无线网卡后飞行模式没有显示

### DIFF
--- a/dcc-network-plugin/dccnetworkmodule.cpp
+++ b/dcc-network-plugin/dccnetworkmodule.cpp
@@ -133,16 +133,15 @@ void DCCNetworkModule::active()
     initListConfig();
     m_indexWidget->showDefaultWidget();
 
-    if (supportAirplaneMode()) {
+    if (getAirplaneDconfig()) {
         m_networkInter = new NetworkInter("com.deepin.daemon.Network", "/com/deepin/daemon/Network", QDBusConnection::sessionBus(), this);
         connect(m_networkInter, &NetworkInter::WirelessAccessPointsChanged, this, &DCCNetworkModule::onWirelessAccessPointsOrAdapterChange);
 
         m_bluetoothInter = new BluetoothInter("com.deepin.daemon.Bluetooth", "/com/deepin/daemon/Bluetooth", QDBusConnection::sessionBus(), this);
         connect(m_bluetoothInter, &BluetoothInter::AdapterAdded, this, &DCCNetworkModule::onWirelessAccessPointsOrAdapterChange);
         connect(m_bluetoothInter, &BluetoothInter::AdapterRemoved, this, &DCCNetworkModule::onWirelessAccessPointsOrAdapterChange);
-    } else {
-        onWirelessAccessPointsOrAdapterChange();
     }
+    onWirelessAccessPointsOrAdapterChange();
 }
 
 QStringList DCCNetworkModule::availPage() const
@@ -351,6 +350,15 @@ bool DCCNetworkModule::supportAirplaneMode() const
     }
 
     return false;
+}
+
+bool DCCNetworkModule::getAirplaneDconfig() const
+{
+    bool airplane = false;
+    if (m_dconfig && m_dconfig->isValid()) {
+        airplane = m_dconfig->value("networkAirplaneMode", false).toBool();
+    }
+    return airplane;
 }
 
 void DCCNetworkModule::initSearchData()

--- a/dcc-network-plugin/dccnetworkmodule.h
+++ b/dcc-network-plugin/dccnetworkmodule.h
@@ -113,6 +113,7 @@ private:
     void initListConfig();
     bool hasModule(const PageType &type);
     bool supportAirplaneMode() const;
+    bool getAirplaneDconfig() const;
 
 private Q_SLOTS:
     void showWirelessEditPage(NetworkDeviceBase *dev, const QString &connUuid = QString(), const QString &apPath = QString());


### PR DESCRIPTION
需要关联设备信号,刷新飞行模式

Log: 飞行模式热插拔显示和隐藏
Influence: 飞行模式
Task: https://pms.uniontech.com/bug-view-155145.html