### PR TITLE
fix: 修复密码选项保存失效的问题

### DIFF
--- a/dcc-network-plugin/sections/secret8021xsection.cpp
+++ b/dcc-network-plugin/sections/secret8021xsection.cpp
@@ -53,7 +53,7 @@ Secret8021xSection::Secret8021xSection(Security8021xSetting::Ptr sSetting, QFram
     m_currentEapMethod = eapMethods.isEmpty() ? Security8021xSetting::EapMethodTls : eapMethods.first();
 
     // init password type
-    Setting::SecretFlags passwordFlags = m_secretSetting->passwordFlags();
+    Setting::SecretFlags passwordFlags = m_currentEapMethod == Security8021xSetting::EapMethodTls ? m_secretSetting->privateKeyPasswordFlags() : m_secretSetting->passwordFlags();
     for (auto it = PasswordFlagsStrMap.cbegin(); it != PasswordFlagsStrMap.cend(); ++it) {
         if (passwordFlags.testFlag(it->second)) {
             m_currentPasswordType = it->second;


### PR DESCRIPTION
企业版和其他的安全选项存储的配置不一样，需要进行区分

Log: 修复密码选项保存失效的问题
Influence: 密码选项由存储所有用户密码更改成仅为该用户存储密码后,重新打开仍生效
Bug: https://pms.uniontech.com/bug-view-154531.html
Change-Id: Ie2eb244c34929f0afb3a79cdbedc2ba7c6c7c417