### PR TITLE
fix: 修复隐藏网络连接失败的问题

### DIFF
--- a/common-plugin/networkpluginhelper.h
+++ b/common-plugin/networkpluginhelper.h
@@ -36,6 +36,7 @@ namespace dde {
 namespace network {
 enum class DeviceType;
 class NetworkDeviceBase;
+class AccessPoints;
 } // namespace network
 } // namespace dde
 
@@ -77,14 +78,18 @@ private:
     bool deviceEnabled(const DeviceType &deviceType) const;
     void setDeviceEnabled(const DeviceType &deviceType, bool enabeld);
     bool wirelessIsActive() const;
+    void handleAccessPointSecure(AccessPoints *accessPoint);
 
     int deviceCount(const DeviceType &devType) const;
     QList<QPair<QString, QStringList>> ipTipsMessage(const DeviceType &devType);
+    bool needSetPassword(AccessPoints *accessPoint) const;
 
 private Q_SLOTS:
     void onDeviceAdded(QList<NetworkDeviceBase *> devices);
     void onUpdatePlugView();
     void onActiveConnectionChanged();
+
+    void onAccessPointsAdded(QList<AccessPoints *> newAps);
 
 private:
     PluginState m_pluginState;

--- a/dock-example/docktestwidget.cpp
+++ b/dock-example/docktestwidget.cpp
@@ -27,14 +27,20 @@ void DockTestWidget::initDock()
 
 bool DockTestWidget::eventFilter(QObject *object, QEvent *event)
 {
-    if (object == m_networkPlugin->itemWidget(NETWORK_KEY)) {
-        if (event->type() == QEvent::Enter) {
-            m_networkPlugin->itemTipsWidget(NETWORK_KEY)->show();
-            return true;
-        } else if (event->type() == QEvent::Leave) {
-            m_networkPlugin->itemTipsWidget(NETWORK_KEY)->hide();
-            return true;
-        }
+    if (object != m_networkPlugin->itemWidget(NETWORK_KEY))
+        return QWidget::eventFilter(object, event);
+
+    QWidget *tipWidget = m_networkPlugin->itemTipsWidget(NETWORK_KEY);
+    if (!tipWidget)
+        return QWidget::eventFilter(object, event);
+
+    if (event->type() == QEvent::Enter) {
+        tipWidget->show();
+        return true;
+    }
+    if (event->type() == QEvent::Leave) {
+        tipWidget->hide();
+        return true;
     }
 
     return QWidget::eventFilter(object, event);
@@ -44,8 +50,10 @@ void DockTestWidget::enterEvent(QEvent *event)
 {
     Q_UNUSED(event);
     QWidget *tip = m_networkPlugin->itemTipsWidget(NETWORK_KEY);
-    tip->setFixedSize(200, 300);
-    tip->show();
+    if (tip) {
+        tip->setFixedSize(200, 300);
+        tip->show();
+    }
 }
 
 void DockTestWidget::itemAdded(PluginsItemInterface * const itemInter, const QString &itemKey)

--- a/dock-example/docktestwidget.h
+++ b/dock-example/docktestwidget.h
@@ -12,13 +12,13 @@ class DockTestWidget : public QWidget, public PluginProxyInterface
 
 public:
     explicit DockTestWidget(QWidget *parent = nullptr);
-    ~DockTestWidget();
+    ~DockTestWidget() override;
 
 private:
     void initDock();
 
-    bool eventFilter(QObject *object, QEvent *event);
-    void enterEvent(QEvent *event);
+    bool eventFilter(QObject *object, QEvent *event) override;
+    void enterEvent(QEvent *event) override;
 
 private:
     void itemAdded(PluginsItemInterface * const itemInter, const QString &itemKey) override;

--- a/src/realize/devicemanagerrealize.cpp
+++ b/src/realize/devicemanagerrealize.cpp
@@ -528,6 +528,7 @@ void DeviceManagerRealize::createWlans(QList<WirelessConnection *> &allConnectio
         AccessPoints *accessPoint = findAccessPoints(ap->ssid());
         if (!accessPoint) {
             accessPoint = new AccessPoints(json);
+            accessPoint->m_devicePath = path();
             newAps << accessPoint;
         } else {
             accessPoint->updateAccessPoints(json);

--- a/src/wirelessdevice.cpp
+++ b/src/wirelessdevice.cpp
@@ -209,10 +209,15 @@ AccessPoints::WlanType AccessPoints::type() const
 void AccessPoints::updateAccessPoints(const QJsonObject &json)
 {
     int nOldStrength = strength();
+    bool oldSecured = secured();
     m_json = json;
     int nStrength = strength();
     if (nOldStrength != -1 && nStrength != nOldStrength)
         Q_EMIT strengthChanged(nStrength);
+
+    bool newSecured = secured();
+    if (oldSecured != newSecured)
+        Q_EMIT securedChanged(newSecured);
 }
 
 void AccessPoints::updateConnectionStatus(ConnectionStatus status)

--- a/src/wirelessdevice.h
+++ b/src/wirelessdevice.h
@@ -114,6 +114,7 @@ public:
 Q_SIGNALS:
     void strengthChanged(const int) const;                          // 当前信号强度变化
     void connectionStatusChanged(ConnectionStatus);
+    void securedChanged(bool);
 
 protected:
     void updateAccessPoints(const QJsonObject &json);


### PR DESCRIPTION
当隐藏网络是否加密状态发生变化的时候，让其来显示密码框

Log: 修复隐藏网络连接失败的问题
Influence: ARM平台且wayland下，连接隐藏网络
Bug: https://pms.uniontech.com/bug-view-155277.html