### PR TITLE
fix: 修复在控制中心连接隐藏网络后任务栏弹出输入密码的提示

### DIFF
--- a/common-plugin/secretagent.h
+++ b/common-plugin/secretagent.h
@@ -108,6 +108,7 @@ private:
      */
     bool hasSecrets(const NMVariantMapMap &connection) const;
     void sendSecrets(const NMVariantMapMap &secrets, const QDBusMessage &message) const;
+    bool needConnectNetwork(const NMVariantMapMap &connectionMap) const;
 
     mutable QProcess *m_process = nullptr;
     QList<SecretsRequest> m_calls;

--- a/dss-network-plugin/network_module.h
+++ b/dss-network-plugin/network_module.h
@@ -72,8 +72,9 @@ private:
     bool hasConnection(NetworkManager::WiredDevice *nmDevice, NetworkManager::Connection::List &unSaveDevices);
     const QString connectionMatchName() const;
     void installTranslator(QString locale);
+    bool needPopupNetworkDialog() const;
 
-public:
+private:
     NETWORKPLUGIN_NAMESPACE::NetworkPluginHelper *m_networkHelper;
     NETWORKPLUGIN_NAMESPACE::NetworkDialog *m_networkDialog;
     NETWORKPLUGIN_NAMESPACE::SecretAgent *m_secretAgent;
@@ -84,6 +85,7 @@ public:
     QSet<QString> m_devicePaths; // 记录无线设备Path,防止信号重复连接
     QString m_lastActiveWirelessDevicePath;
     QString m_lastConnection;
+    QString m_lastConnectionUuid;
     NetworkManager::Device::State m_lastState;
     int m_clickTime;
     mutable QList<QPointer<NETWORKPLUGIN_NAMESPACE::TrayIcon>> trayIcons;


### PR DESCRIPTION
之前是通过获取本地网络库的连接来获取连接的UUID，但是在刚刚连接隐藏网络的时候，网络库还未收到后端连接变化的信息，因此修改成从NetworkManagerQt中获取连接的方式来获取uuid

Log: 优化连接隐藏网络逻辑
Influence: 打开控制中心，连接隐藏网络，输入密码，观察任务栏是否弹出网络框让输入密码
Bug: https://pms.uniontech.com/bug-view-158483.html