### PR TITLE
chore: add logging category

### DIFF
--- a/src/netutils.cpp
+++ b/src/netutils.cpp
@@ -4,6 +4,12 @@
 
 #include "netutils.h"
 
+#ifndef QT_DEBUG
+Q_LOGGING_CATEGORY(dncd, "dde.network.core.dev" , QtInfoMsg);
+#else
+Q_LOGGING_CATEGORY(dncd, "dde.network.core.dev");
+#endif
+
 namespace dde {
 namespace network {
 

--- a/src/netutils.h
+++ b/src/netutils.h
@@ -9,15 +9,18 @@
 
 #include <QDebug>
 #include <QJsonObject>
+#include <QLoggingCategory>
 
 #include "com_deepin_daemon_network.h"
 #include "com_deepin_daemon_network_proxychains.h"
 
+Q_DECLARE_LOGGING_CATEGORY(dncd);
+
 namespace dde {
 namespace network {
 
-#define PRINT_INFO_MESSAGE(msg) qInfo() << __FILE__ << "line:" << __LINE__ << "function:" << __FUNCTION__ << "Message:" << msg
-#define PRINT_DEBUG_MESSAGE(msg) qDebug() << __FILE__ << "line:" << __LINE__ << "function:" << __FUNCTION__ << "Message:" << msg
+#define PRINT_INFO_MESSAGE(msg) qCInfo(dncd) << __FILE__ << "line:" << __LINE__ << "function:" << __FUNCTION__ << "Message:" << msg
+#define PRINT_DEBUG_MESSAGE(msg) qCDebug(dncd) << __FILE__ << "line:" << __LINE__ << "function:" << __FUNCTION__ << "Message:" << msg
 
 // an alias for numeric zero, no flags set.
 #define DEVICE_INTERFACE_FLAG_NONE 0


### PR DESCRIPTION
too many log message, use logging category to
enable or disbale logging message.
e.g. in dde-dock network plugin
QT_LOGGING_RULES="dde.network.core.dev=true" dde-dock

Log: logging category
Influence: network logging message
Change-Id: Ia050d69a9751446ca948186af6412b88b2fa06f9