### PR TITLE
fix: wifi列表背景颜色

### DIFF
--- a/dde-network-dialog/thememanager.cpp
+++ b/dde-network-dialog/thememanager.cpp
@@ -124,7 +124,7 @@ QColor ThemeManager::backgroundColor()
         return QColor(0, 0, 0, alpha);
     case GreeterType:
     case LockType:
-        return QColor(235, 235, 235, alpha);
+        return QColor(235, 235, 235, static_cast<int>(0.05 * 255));
     default:
         return QColor(255, 255, 255, alpha);
     }


### PR DESCRIPTION
现象：锁屏界面wifi列表背景颜色和数据颜色均显示白色,看着不够清晰。
方案：调整透明度

Log: 调整锁屏界面wifi弹窗透明度
Bug: https://pms.uniontech.com/bug-view-159545.html
Influence: 网络弹窗
Change-Id: I8999738dde34c3b9c39f9bfeb4d4de729d9f32ec