### PR TITLE
fix: 修改任务栏在触发连接隐藏网络密码输入弹窗后hover无tips显示问题

### DIFF
--- a/common-plugin/networkdialog.cpp
+++ b/common-plugin/networkdialog.cpp
@@ -66,6 +66,7 @@ NetworkDialog::NetworkDialog(QObject *parent)
     , m_saveMode(false)
     , m_serverName(NetworkDialogApp + QString::number(getuid()))
     , m_visible(false)
+    , m_start(false)
 {
     m_server = new QLocalServer(this);
     connect(m_server, SIGNAL(newConnection()), this, SLOT(newConnectionHandler()));
@@ -166,6 +167,9 @@ bool NetworkDialog::eventFilter(QObject *watched, QEvent *e)
 
 void NetworkDialog::runProcess(bool show)
 {
+    if (!m_start)
+        return;
+
     QStringList argList;
     if (show) {
         argList << "-s" << showConfig();
@@ -218,6 +222,7 @@ void NetworkDialog::setLocale(const QString &locale)
 
 void NetworkDialog::runServer(bool start)
 {
+    m_start = start;
     if (!start)
         return;
 

--- a/common-plugin/networkdialog.h
+++ b/common-plugin/networkdialog.h
@@ -107,6 +107,7 @@ private:
     QString m_serverName;
     bool m_visible;
     QString m_locale;
+    bool m_start;
 };
 
 NETWORKPLUGIN_END_NAMESPACE


### PR DESCRIPTION
锁屏程序监听到隐藏网络需要密码输入弹窗，启动了网络面板。该网络面板一直在后台运行，任务栏判断为有一个网络面板弹出了，没显示tips单击不弹窗

Log: 修改任务栏连接隐藏网络，概率性再点击无网络面板弹窗问题
Bug: https://pms.uniontech.com/bug-view-160229.html
Influence: 任务栏-网络-网络面板连接隐藏网络，修改网络密码后触发密码输入弹窗