### PR TITLE
fix: 修复网络密码保存为当前用户重启后无法自动连接的问题

### DIFF
--- a/common-plugin/secretagent.cpp
+++ b/common-plugin/secretagent.cpp
@@ -64,10 +64,6 @@ NMVariantMapMap SecretAgent::GetSecrets(const NMVariantMapMap &connection,
     DEBUG_PRINT << "Hints:" << hints;
     DEBUG_PRINT << "Flags:" << flags;
 
-    // 如果当前网络连接的密码是按照所有用户保存的，则正常处理这些请求，否则，就无需处理
-    if (!needConnectNetwork(connection))
-        return {};
-
     const QString callId = connection_path.path() % setting_name;
     for (const SecretsRequest &request : m_calls) {
         if (request == callId) {
@@ -228,6 +224,8 @@ void SecretAgent::readProcessOutput()
                                 request.connection[request.setting_name] = result;
                                 sendSecrets(request.connection, request.message);
                             }
+                        } else {
+                            sendError(SecretAgent::UserCanceled, QStringLiteral("user canceled"), request.message);
                         }
 
                         break;
@@ -302,6 +300,11 @@ bool SecretAgent::processGetSecrets(SecretsRequest &request) const
             return true;
         }
 
+        if (!userRequested) {
+            sendError(SecretAgent::AgentCanceled, QStringLiteral("dss only support user quest"), request.message);
+            return true;
+        }
+
         m_process = new QProcess;
 
         connect(m_process, static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(&QProcess::finished), this, &SecretAgent::dialogFinished);
@@ -349,25 +352,6 @@ bool SecretAgent::processGetSecrets(SecretsRequest &request) const
         sendError(SecretAgent::InternalError, QStringLiteral("dss did not know how to handle the request"), request.message);
         return true;
     }
-}
-
-// 判断当前
-bool SecretAgent::needConnectNetwork(const NMVariantMapMap &connectionMap) const
-{
-    // 如果不是登陆界面的连接（任务栏的请求），就让其始终响应请求
-    if (!m_greeter)
-        return true;
-
-    NetworkManager::ConnectionSettings::Ptr connectionSettings =
-        NetworkManager::ConnectionSettings::Ptr(new NetworkManager::ConnectionSettings(connectionMap));
-    NetworkManager::Connection::Ptr connection = NetworkManager::findConnectionByUuid(connectionSettings->uuid());
-    if (connection.isNull())
-        return true;
-
-    // 如果当前连接的密码是按照用户保存的，就不需要处理连接的请求
-    NetworkManager::WirelessSecuritySetting::Ptr securitySetting = connection->settings()->setting(NetworkManager::Setting::SettingType::WirelessSecurity).staticCast<NetworkManager::WirelessSecuritySetting>();
-    NetworkManager::Setting::SecretFlags passwordFlags = securitySetting->pskFlags();
-    return (passwordFlags.testFlag(NetworkManager::Setting::None));
 }
 
 bool SecretAgent::processSaveSecrets(SecretsRequest &request) const

--- a/dss-network-plugin/network_module.cpp
+++ b/dss-network-plugin/network_module.cpp
@@ -88,10 +88,8 @@ QWidget *NetworkModule::content()
     int msec = QTime::currentTime().msecsSinceStartOfDay();
     if (!m_networkDialog->isVisible() && abs(msec - m_clickTime) > 200) {
         m_clickTime = msec;
-        if (needPopupNetworkDialog()) {
-            emit signalShowNetworkDialog();
-            m_networkDialog->show();
-        }
+        emit signalShowNetworkDialog();
+        m_networkDialog->show();
     }
     return nullptr;
 }
@@ -307,6 +305,9 @@ bool NetworkModule::needPopupNetworkDialog() const
 
     // 如果当前连接的密码是按照用户保存的，就不弹出来
     WirelessSecuritySetting::Ptr securitySetting = connection->settings()->setting(Setting::SettingType::WirelessSecurity).staticCast<WirelessSecuritySetting>();
+    if (securitySetting.isNull())
+        return true;
+
     NetworkManager::Setting::SecretFlags passwordFlags = securitySetting->pskFlags();
     return (passwordFlags.testFlag(Setting::None));
 }


### PR DESCRIPTION
原因：登陆界面发现当前网络是保存为当前用户的时候，则弹出网络列表让用户输入密码，用户点击其他区域后，就取消了连接的操作，导致进入桌面后无法自动连接这个网络 修改：在登陆界面不让自动连接保存为当前用户的网络，进入桌面后就会自动连接到这个网络

Log: 修改无线网络保存为当前用户后重启系统无法自动连接的问题
Influence: 在控制中心连接加密网络，选择为保存当前用户，重启后进入桌面观察是否自动连接
Bug: https://pms.uniontech.com/bug-view-158911.html