### PR TITLE
fix: 网络库类型未注册qDbus导致锁屏异常退出

### DIFF
--- a/common-plugin/networkpluginhelper.cpp
+++ b/common-plugin/networkpluginhelper.cpp
@@ -71,6 +71,7 @@ NetworkPluginHelper::NetworkPluginHelper(NetworkDialog *networkDialog, QObject *
     , m_switchWire(true)
     , m_networkDialog(networkDialog)
 {
+    qDBusRegisterMetaType<NMVariantMapMap>();
     initUi();
     initConnection();
 }


### PR DESCRIPTION
注册NMVariantMapMap类型，防止类型未注册导致主程序异常退出

Log: 修复网络库类型未注册qDbus导致锁屏异常退出的问题
Bug: https://pms.uniontech.com/bug-view-159567.html
Influence: 锁屏界面正常显示
Change-Id: I196172d26c3815874cd883469bd5776b20fcfab0