### PR TITLE
fix: 修复secret agent 崩溃问题

### DIFF
--- a/common-plugin/secretagent.cpp
+++ b/common-plugin/secretagent.cpp
@@ -127,6 +127,8 @@ void SecretAgent::CancelGetSecrets(const QDBusObjectPath &connection_path, const
         SecretsRequest request = m_calls.at(i);
         if (request.type == SecretsRequest::GetSecrets && callId == request.callId) {
             if (m_process == request.process) {
+                DEBUG_PRINT << "process finished (agent canceled)";
+                m_process->deleteLater();
                 m_process = nullptr;
             }
             sendError(SecretAgent::AgentCanceled, QStringLiteral("Agent canceled the password dialog"), request.message);
@@ -169,6 +171,8 @@ void SecretAgent::processNext()
 
 void SecretAgent::dialogFinished()
 {
+    if (!m_process) return;
+
     readProcessOutput();
 
     for (int i = 0; i < m_calls.size(); ++i) {


### PR DESCRIPTION
当用户注消连接会触发secret agent cancel 行为，导致对话框进程变空指针。

Log:
Task: https://pms.uniontech.com/task-view-196123.html
Influence: 登陆网络认证
Change-Id: I5addc901fa1caf75bbbc09b9653cf4ead3c3084e