### PR TITLE
fix: 修复任务栏连接状态错误的问题

### DIFF
--- a/common-plugin/networkpluginhelper.cpp
+++ b/common-plugin/networkpluginhelper.cpp
@@ -66,7 +66,6 @@ using DBusAirplaneMode = com::deepin::daemon::AirplaneMode;
 
 NetworkPluginHelper::NetworkPluginHelper(NetworkDialog *networkDialog, QObject *parent)
     : QObject(parent)
-    , m_pluginState(PluginState::Unknow)
     , m_tipsWidget(new TipsWidget(nullptr))
     , m_switchWire(true)
     , m_networkDialog(networkDialog)
@@ -102,14 +101,9 @@ void NetworkPluginHelper::initConnection()
     });
 }
 
-void NetworkPluginHelper::updatePluginState()
-{
-    m_pluginState = DeviceStatusHandler::pluginState();
-}
-
 PluginState NetworkPluginHelper::getPluginState()
 {
-    return m_pluginState;
+    return DeviceStatusHandler::pluginState();
 }
 
 QList<QPair<QString, QStringList>> NetworkPluginHelper::ipTipsMessage(const DeviceType &devType)
@@ -139,7 +133,7 @@ QList<QPair<QString, QStringList>> NetworkPluginHelper::ipTipsMessage(const Devi
 
 void NetworkPluginHelper::updateTooltips()
 {
-    switch (m_pluginState) {
+    switch (getPluginState()) {
     case PluginState::Connected: {
         QList<QPair<QString, QStringList>> textList;
         textList << ipTipsMessage(DeviceType::Wireless) << ipTipsMessage(DeviceType::Wired);
@@ -420,7 +414,6 @@ QWidget *NetworkPluginHelper::itemTips()
 
 void NetworkPluginHelper::onUpdatePlugView()
 {
-    updatePluginState();
     updateTooltips();
     emit viewUpdate();
 }

--- a/common-plugin/networkpluginhelper.h
+++ b/common-plugin/networkpluginhelper.h
@@ -69,7 +69,6 @@ public:
     const QString contextMenu(bool hasSetting) const;
     QWidget *itemTips();
     PluginState getPluginState();
-    void updatePluginState();
     void updateTooltips(); // 更新提示的内容
 
 private:
@@ -92,8 +91,6 @@ private Q_SLOTS:
     void onAccessPointsAdded(QList<AccessPoints *> newAps);
 
 private:
-    PluginState m_pluginState;
-
     TipsWidget *m_tipsWidget;
     bool m_switchWire;
     QPixmap m_iconPixmap;

--- a/src/realize/deviceinterrealize.h
+++ b/src/realize/deviceinterrealize.h
@@ -60,6 +60,7 @@ public:
     QJsonObject activeConnectionInfo() const override;                                                       // 获取当前活动连接的信息
     void setEnabled(bool enabled) override;                                                                  // 开启或禁用网卡
     Connectivity connectivity();
+    DeviceStatus deviceStatus() const override;
 
 protected:
     explicit DeviceInterRealize(IPConfilctChecker *ipChecker, NetworkInter *networkInter, QObject *parent = Q_NULLPTR);
@@ -75,7 +76,6 @@ protected:
     virtual void setDeviceEnabledStatus(const bool &enabled);
     virtual void updateActiveInfo(const QList<QJsonObject> &) {}                                        // 当前连接发生变化，例如从一个连接切换到另外一个连接
     virtual void updateActiveConnectionInfo(const QList<QJsonObject> &infos);                               // 当前连接发生变化后，获取设备的活动信息，例如IP等
-    void setDeviceStatus(const DeviceStatus &status) override;
     int mode() const;
 
 private:


### PR DESCRIPTION
任务栏的连接状态从后端服务读取,改成从网络服务的DBus接口来读取,保证状态始终是正确的

Log: 修复任务栏状态显示错误的问题
Influence: 偶现在网络全部连接成功后,任务栏网络图标显示正在连接,观察这种情况是否存在
Bug: https://pms.uniontech.com/bug-view-150305.html