### PR TITLE
fix: 刷新网络连接状态时更新网线是否插入提示信息是否可见

### DIFF
--- a/dcc-network-plugin/wiredpage.cpp
+++ b/dcc-network-plugin/wiredpage.cpp
@@ -180,6 +180,9 @@ void WiredPage::onUpdateConnectionStatus()
     }
 
     m_modelprofiles->sort(0);
+
+    // 刷新网络状态时刷新网线是否插入提示信息
+    onDeviceStatusChanged(m_device->deviceStatus());
 }
 
 void WiredPage::onConnectionPropertyChanged(const QList<WiredConnection *> &changedConnection)


### PR DESCRIPTION
刷新网络连接状态时更新网线是否插入提示信息是否可见

Log: 修复插拔网线后有线网络界面不会立即刷新问题
Bug: https://pms.uniontech.com/bug-view-164591.html
Influence: 插拔网线后有线网络界面及时刷新