### PR TITLE
fix: 缩放后无法使用虚拟键盘输入网络密码

### DIFF
--- a/dde-network-dialog/dockpopupwindow.h
+++ b/dde-network-dialog/dockpopupwindow.h
@@ -57,6 +57,7 @@ protected:
     void enterEvent(QEvent *e);
     bool eventFilter(QObject *o, QEvent *e);
     void paintEvent(QPaintEvent *event);
+    QPoint scalePoint(QPoint point);
 
 private slots:
     void compositeChanged();


### PR DESCRIPTION
onboard的坐标并未进行缩放，导致判断鼠标是否在onboard内时发生错误

Log: 修复缩放后无法使用虚拟键盘输入网络密码的问题
Bug: https://pms.uniontech.com/bug-view-165195.html
Influence: 缩放时使用虚拟键盘输入网络密码
Change-Id: Id3caf59b6e4f9dfa723d8aa25fc7f0675cce9a83