### PR TITLE
fix: 修复网络偶现崩溃

### DIFF
--- a/src/realize/devicemanagerrealize.h
+++ b/src/realize/devicemanagerrealize.h
@@ -58,28 +58,19 @@ protected:
     QList<WiredConnection *> wiredItems() const override;                                 // 有线网络连接列表
 
 private:
-    template<class T>
-    void clearListData(QList<T *> &dataList) {
-        for (T *data : dataList)
-            delete data;
-
-        dataList.clear();
-    }
-
-private:
     void initSigSlotConnection();
-    void createWlans(QList<WirelessConnection *> &allConnections);
-    void syncWlanAndConnections(QList<WirelessConnection *> &allConnections);
+    void createWlans(QList<QSharedPointer<WirelessConnection >> &allConnections);
+    void syncWlanAndConnections(QList<QSharedPointer<WirelessConnection>> &allConnections);
 
-    AccessPoints *findAccessPoints(const QString &ssid);
+    QSharedPointer<AccessPoints> findAccessPoints(const QString &ssid);
     QJsonObject createWlanJson(QSharedPointer<NetworkManager::AccessPoint> ap);
     QJsonObject createConnectionJson(QSharedPointer<NetworkManager::Connection> networkConnection);
-    WirelessConnection *findConnectionByAccessPoint(const AccessPoints *accessPoint, QList<WirelessConnection *> &allConnections);
+    QSharedPointer<WirelessConnection> findConnectionByAccessPoint(const AccessPoints *accessPoint, QList<QSharedPointer<WirelessConnection>> &allConnections);
 
     WiredConnection *findWiredConnection(const QString &path);
     WiredConnection *findWiredConnectionByUuid(const QString &uuid);
-    WirelessConnection *findWirelessConnectionBySsid(const QString &ssid);
-    WirelessConnection *findWirelessConnection(const QString &path);
+    QSharedPointer<WirelessConnection> findWirelessConnectionBySsid(const QString &ssid);
+    QSharedPointer<WirelessConnection> findWirelessConnection(const QString &path);
     WirelessConnection *findWirelessConnectionByUuid(const QString &uuid);
     ConnectionStatus convertStatus(Device::State state);
     DeviceStatus convertDeviceStatus(Device::State state);
@@ -98,9 +89,9 @@ private slots:
 
 private:
     QSharedPointer<Device> m_wDevice;
-    QList<AccessPoints *> m_accessPoints;
+    QList<QSharedPointer<AccessPoints>> m_accessPoints;
     QList<WiredConnection *> m_wiredConnections;
-    QList<WirelessConnection *> m_wirelessConnections;
+    QList<QSharedPointer<WirelessConnection>> m_wirelessConnections;
     WiredConnection *m_activeWiredConnection;
     WirelessConnection *m_activeWirelessConnection;
     bool m_hotspotEnabled;

--- a/src/wirelessdevice.h
+++ b/src/wirelessdevice.h
@@ -79,9 +79,9 @@ public:
 
 protected:
     AccessPoints(const QJsonObject &json, QObject *parent = Q_NULLPTR);
-    ~AccessPoints();
 
 public:
+    ~AccessPoints();
     QString ssid() const;                                           // 网络SSID，对应于返回接口中的Ssid
     int strength() const;                                           // 信号强度，对应于返回接口中的Strength
     bool secured() const;                                           // 是否加密，对应于返回接口中的Secured
@@ -120,13 +120,12 @@ class WirelessConnection: public ControllItems
     friend class DeviceManagerRealize;
 
 public:
+    WirelessConnection();
     AccessPoints *accessPoints() const;                             // 返回当前对应的wlan的指针
+    ~WirelessConnection();
     bool connected();                                               // 网络是否连接成功
 
 protected:
-    WirelessConnection();
-    ~WirelessConnection();
-
     static WirelessConnection *createConnection(AccessPoints *ap);
 
 private:


### PR DESCRIPTION
原来的指针对象用的是普通的指针维护，在删除的时候容易重复删除引起崩溃；改成智能指针来管理指针对象

Log: 修复登陆界面网络崩溃的问题
Influence: 笔记本在登陆节目合上，再打开，观察是否会出现黑屏
Bug: https://pms.uniontech.com/bug-view-154983.html (cherry picked from commit 723d0681ff99a9e7dfe88ccb3bdab52a17b53d81)