### PR TITLE
fix: 修复控制中心网卡不显示当前网络的连接状态的问题

### DIFF
--- a/src/realize/deviceinterrealize.cpp
+++ b/src/realize/deviceinterrealize.cpp
@@ -150,6 +150,9 @@ Connectivity DeviceInterRealize::connectivity()
 
 DeviceStatus DeviceInterRealize::deviceStatus() const
 {
+    if (mode() == AP_MODE)
+        return DeviceStatus::Disconnected;
+
     NetworkManager::Device::Ptr dev(new NetworkManager::Device(path()));
     switch(dev->state()) {
     case NetworkManager::Device::State::UnknownState:
@@ -202,6 +205,7 @@ NetworkInter *DeviceInterRealize::networkInter()
 void DeviceInterRealize::updateDeviceInfo(const QJsonObject &info)
 {
     m_data = info;
+    NetworkDeviceRealize::setDeviceStatus(deviceStatus());
 }
 
 void DeviceInterRealize::initDeviceInfo()
@@ -251,6 +255,12 @@ void DeviceInterRealize::updateActiveConnectionInfo(const QList<QJsonObject> &in
     }
     if (ipChanged)
         Q_EMIT ipV4Changed();
+}
+
+void DeviceInterRealize::setDeviceStatus(const DeviceStatus &status)
+{
+    Q_UNUSED(status);
+    NetworkDeviceRealize::setDeviceStatus(deviceStatus());
 }
 
 int DeviceInterRealize::mode() const

--- a/src/realize/deviceinterrealize.h
+++ b/src/realize/deviceinterrealize.h
@@ -59,6 +59,7 @@ protected:
     virtual void setDeviceEnabledStatus(const bool &enabled);
     virtual void updateActiveInfo(const QList<QJsonObject> &) {}                                        // 当前连接发生变化，例如从一个连接切换到另外一个连接
     virtual void updateActiveConnectionInfo(const QList<QJsonObject> &infos);                               // 当前连接发生变化后，获取设备的活动信息，例如IP等
+    void setDeviceStatus(const DeviceStatus &status) override;
     int mode() const;
 
 private:


### PR DESCRIPTION
在网络状态更新的时候，调用父类的setDeviceStatus方法来设置网络状态

Log: 修复控制中心不现实当前网络连接状态的问题
Influence: 打开控制中心，观察左侧网卡的连接状态
Bug: https://pms.uniontech.com/bug-view-166645.html
Bug: https://pms.uniontech.com/bug-view-171061.html