### PR TITLE
fix: 修复部份网络无法连接隐藏热点的问题

### DIFF
--- a/common-plugin/networkdialog/item/netitem.cpp
+++ b/common-plugin/networkdialog/item/netitem.cpp
@@ -616,13 +616,9 @@ void WirelessItem::onConnectNetwork()
     QString password = m_passwdEdit->text();
     // 输入无效在checkInputValid里已判断
     if (m_wirelessConnect->passwordIsValid(password)) {
-        if (m_accessPoint) {
-            if (m_panel->changePassword(m_accessPoint->ssid(), password, true)) {
-                expandWidget(ExpandWidget::Hide, false);
-                return;
-            }
+        if (!m_wirelessConnect->connectNetworkPassword(m_passwdEdit->text()) && m_accessPoint) {
+            m_panel->changePassword(m_accessPoint->ssid(), password, true);
         }
-        m_wirelessConnect->connectNetworkPassword(m_passwdEdit->text());
         expandWidget(ExpandWidget::Hide, false);
     }
 }
@@ -648,7 +644,7 @@ void WirelessItem::onConnectHidden()
     QString ssid = m_ssidEdit->text();
     if (!ssid.isEmpty()) {
         expandWidget(ExpandWidget::Hide, false);
-        m_wirelessConnect->setSsid(m_ssidEdit->text());
+        m_wirelessConnect->setSsid(ssid);
         m_wirelessConnect->connectNetwork();
     }
 }

--- a/common-plugin/networkdialog/item/wirelessconnect.cpp
+++ b/common-plugin/networkdialog/item/wirelessconnect.cpp
@@ -191,6 +191,10 @@ void WirelessConnect::setPassword(const QString &password)
                || keyMgmt == WirelessSecuritySetting::KeyMgmt::SAE) {
 #endif
         wsSetting->setPsk(password);
+
+        if (isHidden && keyMgmt == WirelessSecuritySetting::KeyMgmt::WpaPsk) {
+            wsSetting->setAuthAlg(WirelessSecuritySetting::AuthAlg::Open);
+        }
     }
     wsSetting->setInitialized(true);
     m_needUpdate = true;
@@ -224,11 +228,19 @@ void WirelessConnect::connectNetwork()
     activateConnection();
 }
 
-void WirelessConnect::connectNetworkPassword(const QString password)
+bool WirelessConnect::connectNetworkPassword(const QString password)
 {
     initConnection();
+
+    WirelessSecuritySetting::Ptr wsSetting = m_connectionSettings->setting(Setting::WirelessSecurity).dynamicCast<WirelessSecuritySetting>();
+    if (wsSetting && !wsSetting->isNull()) {
+        return false;
+    }
+
     setPassword(password);
     activateConnection();
+
+    return true;
 }
 
 void WirelessConnect::activateConnection()

--- a/common-plugin/networkdialog/item/wirelessconnect.h
+++ b/common-plugin/networkdialog/item/wirelessconnect.h
@@ -41,7 +41,7 @@ protected:
 
 public Q_SLOTS:
     void connectNetwork();
-    void connectNetworkPassword(const QString password);
+    bool connectNetworkPassword(const QString password);
 
 Q_SIGNALS:
     void passwordError(const QString oldPassword);

--- a/common-plugin/networkdialog/networkpanel.cpp
+++ b/common-plugin/networkdialog/networkpanel.cpp
@@ -692,7 +692,6 @@ void NetworkPanel::passwordError(const QString &dev, const QString &ssid)
     if (!ssid.isEmpty()) {
         m_reconnectSsid = ssid;
         m_reconnectDev = dev;
-        m_waitPassword = true;
         clear();
     }
     if (!m_reconnectSsid.isEmpty()) {
@@ -700,14 +699,9 @@ void NetworkPanel::passwordError(const QString &dev, const QString &ssid)
     }
 }
 
-bool NetworkPanel::changePassword(const QString &key, const QString &password, bool input)
+void NetworkPanel::changePassword(const QString &key, const QString &password, bool input)
 {
-    if (m_waitPassword) {
-        Q_EMIT passwordChanged(key,password,input);
-        m_waitPassword = false;
-        return true;
-    }
-    return false;
+    Q_EMIT passwordChanged(key,password,input);
 }
 
 QString NetworkPanel::ssidWaitingForPassword() const

--- a/common-plugin/networkdialog/networkpanel.h
+++ b/common-plugin/networkdialog/networkpanel.h
@@ -49,7 +49,7 @@ public:
     QWidget *itemApplet();
     void passwordError(const QString &dev, const QString &ssid);
 
-    bool changePassword(const QString &key, const QString &password, bool input);
+    void changePassword(const QString &key, const QString &password, bool input);
     QString ssidWaitingForPassword() const;
     bool closeOnClear() const;
     void setCloseOnClear(bool closeOnClear);
@@ -97,7 +97,6 @@ private:
     QSet<QString> m_wirelessDevicePath;
     QString m_reconnectDev;
     QString m_reconnectSsid;
-    bool m_waitPassword;
     DBusAirplaneMode *m_airplaneMode;
     QTimer *m_updateTimer;
 };

--- a/dcc-network-plugin/sections/secretwirelesssection.cpp
+++ b/dcc-network-plugin/sections/secretwirelesssection.cpp
@@ -145,7 +145,11 @@ void SecretWirelessSection::saveSettings()
             m_wsSetting->setPsk(QString());
 
         m_wsSetting->setWepKeyType(WirelessSecuritySetting::WepKeyType::NotSpecified);
-        m_wsSetting->setAuthAlg(WirelessSecuritySetting::AuthAlg::None);
+        if (m_currentKeyMgmt == WirelessSecuritySetting::KeyMgmt::WpaPsk) {
+            m_wsSetting->setAuthAlg(WirelessSecuritySetting::AuthAlg::Open);
+        } else {
+            m_wsSetting->setAuthAlg(WirelessSecuritySetting::AuthAlg::None);
+        }
     } else if (m_currentKeyMgmt == WirelessSecuritySetting::KeyMgmt::WpaEap) {
         m_wsSetting->setAuthAlg(WirelessSecuritySetting::AuthAlg::None);
     }


### PR DESCRIPTION
nm 不会对隐藏热点的settings进行补全，需要下游自行决定，
wpa-psk 不设置认证为 open 可能导致无法连接热点。

Log: 修复部份网络无法连接隐藏热点的问题
Bug: https://pms.uniontech.com/bug-view-155771.html
Influence: wifi
Change-Id: I1e9922fdae5c1254c9868a6dccada5a92bc31fee