### PR TITLE
fix: 修改网络刷新图标为空问题

### DIFF
--- a/common-plugin/networkdialog/networkpanel.cpp
+++ b/common-plugin/networkdialog/networkpanel.cpp
@@ -1061,7 +1061,7 @@ void NetworkDelegate::drawRefreshButton(QPainter *painter, const QStyleOptionVie
         return;
 
     QRect rctIcon(option.rect.width() - SWITCH_WIDTH - 36, option.rect.top() + (option.rect.height() - 20) / 2, 20, 20);
-    QPixmap pixmap = DHiDPIHelper::loadNxPixmap(ThemeManager::instance()->getIcon("wireless/refresh"));
+    QPixmap pixmap = DHiDPIHelper::loadNxPixmap(ThemeManager::instance()->getIcon("refresh"));
     painter->save();
     painter->setRenderHint(QPainter::Antialiasing, true);
     if (m_refreshAngle.contains(index)) {


### PR DESCRIPTION
刷新图标资源名错误

Log: 修改网络刷新图标为空问题
Bug: https://pms.uniontech.com/bug-view-172931.html
Influence: 任务栏、锁屏-网络列表-网络刷新图标