### PR TITLE
fix: 需要延时一段时间再展开密码输入框

### DIFF
--- a/dde-network-dialog/networkpanel.cpp
+++ b/dde-network-dialog/networkpanel.cpp
@@ -665,7 +665,8 @@ void NetworkPanel::passwordError(const QString &dev, const QString &ssid)
         m_reconnectDev = dev;
     }
     if (!m_reconnectSsid.isEmpty()) {
-        QTimer::singleShot(0, this, &NetworkPanel::expandPasswordInput);
+        // 需要延时一段时间再展开密码输入框，否则界面和列表还没有显示出来时，输入框无法获得焦点
+        QTimer::singleShot(150, this, &NetworkPanel::expandPasswordInput);
     }
 }
 


### PR DESCRIPTION
需要延时一段时间再展开密码输入框，否则界面和列表还没有显示出来时，输入框无法获得焦点

Log: 修复控制中心连接点击加密wifi唤起任务栏的网络面板中对应SSID密码框中无光标的问题
Bug: https://pms.uniontech.com/bug-view-172773.html
Influence: 密码输入框显示光标