### PR TITLE
fix: 登录锁屏界面不显示网络弹窗

### DIFF
--- a/dss-network-plugin/network_module.cpp
+++ b/dss-network-plugin/network_module.cpp
@@ -223,7 +223,9 @@ bool NetworkModule::eventFilter(QObject *watched, QEvent *e)
     switch (e->type()) {
     case QEvent::ParentChange: {
         TrayIcon *trayIcon = qobject_cast<TrayIcon *>(watched);
-        if (!trayIcon || !trayIcon->parent() || (trayIcon->parent()->metaObject()->className() != QString("FlotingButton")))
+        // ParentChange可能会进来多次，只需要处理父对象是FloatingButton的情况
+        // FIXME 这种写法增加了与dde-session-shell的耦合性
+        if (!trayIcon || !trayIcon->parent() || (trayIcon->parent()->metaObject()->className() != QString("FloatingButton")))
             break;
         if (!m_isLockModel)
             NotificationManager::InstallEventFilter(trayIcon);


### PR DESCRIPTION
原因：dde-session-shell改了一个类名（因为拼写错误），网络插件会根据这个类名判断是否要注册事件过滤器， 没有注册就无法捕捉到点击事件，从而导致网络弹窗无法弹出

Log：修复网络弹窗无法弹出的问题
Bug：https://pms.uniontech.com/bug-view-173777.html Influence：登录锁屏界面网络弹窗

Change-Id: I564926b9e7d641daf4d7d4e31bcf254740e0c41f