### PR TITLE
fix: 任务栏无线网络密码输入框焦点显示异常

### DIFF
--- a/dde-network-dialog/thememanager.cpp
+++ b/dde-network-dialog/thememanager.cpp
@@ -126,7 +126,7 @@ QColor ThemeManager::backgroundColor()
     case LockType:
         return QColor(235, 235, 235, static_cast<int>(0.05 * 255));
     default:
-        return QColor(255, 255, 255, alpha);
+        return QColor(255, 255, 255, 255);
     }
     Q_UNREACHABLE();
     return QColor(255, 255, 255, alpha);


### PR DESCRIPTION
当设置的主题类型为浅色模式时，使用白色的背景

Log: 修复任务栏无线网络密码输入框焦点显示异常的问题
Bug: https://pms.uniontech.com/bug-view-172113.html
Influence: 任务栏连接无线网络输入框焦点显示
Change-Id: I8e0f9dfcfa2b2e8e4496593e8a41941e49ebd197