### PR TITLE
fix: 修复个人热点无法开启问题

### DIFF
--- a/dcc-network-plugin/sections/wirelesssection.cpp
+++ b/dcc-network-plugin/sections/wirelesssection.cpp
@@ -70,7 +70,11 @@ bool WirelessSection::allInputValid()
 
 void WirelessSection::saveSettings()
 {
-    m_wirelessSetting->setSsid(m_ssid.toUtf8());
+    if (m_ssid.isEmpty()) {
+        m_wirelessSetting->setSsid(m_connSettings->id().toUtf8());
+    } else {
+        m_wirelessSetting->setSsid(m_ssid.toUtf8());
+    }
 
     const QPair<QString, QString> &pair = m_macStrMap.value(m_deviceMacComboBox->currentText());
     QString hwAddr = pair.first;


### PR DESCRIPTION
开启热点未设置ssid

Log: 修复个人热点无法开启问题
Bug: https://pms.uniontech.com/bug-view-174545.html
Influence: 控制中心-开启个人热点