### PR TITLE
fix: 创建热点时名称不提供默认值由用户自行填写

### DIFF
--- a/dcc-network-plugin/connectioneditpage.cpp
+++ b/dcc-network-plugin/connectioneditpage.cpp
@@ -414,9 +414,6 @@ void ConnectionEditPage::createConnSettings()
         break;
     }
     case ConnectionSettings::ConnectionType::Wireless: {
-        if (m_isHotSpot) {
-            connName = tr("Hotspot");
-        }
         m_connectionSettings->setting(Setting::Security8021x).staticCast<Security8021xSetting>()->setPasswordFlags(Setting::None);
         break;
     }


### PR DESCRIPTION
创建热点时名称不提供默认值由用户自行填写

Log: 创建热点时名称不提供默认值由用户自行填写
Bug: https://pms.uniontech.com/bug-view-175381.html
Influence: 创建热点时名称不提供默认值由用户自行填写