### PR TITLE
fix: 优化图标刷新 (#109)

### DIFF
--- a/common-plugin/trayicon.cpp
+++ b/common-plugin/trayicon.cpp
@@ -29,7 +29,11 @@ TrayIcon::TrayIcon(NetworkPluginHelper *networkHelper)
 
     m_refreshIconTimer->setInterval(100);
     connect(m_refreshIconTimer, &QTimer::timeout, this, &TrayIcon::refreshIcon);
-    connect(m_networkHelper, &NetworkPluginHelper::viewUpdate, this, &TrayIcon::refreshIcon);
+    connect(m_networkHelper, &NetworkPluginHelper::viewUpdate, this, [this]{
+        if (!m_refreshIconTimer->isActive()) {
+            m_refreshIconTimer->start(500);
+        }
+    });
     connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged, this, &TrayIcon::refreshIcon);
     // 在初始化的时候，需要更新本地图标信息，否则可能会出现图标状态显示不正确
     QTimer::singleShot(0, this, [ this ] {


### PR DESCRIPTION
网络变化时，刷新频率过高，优化为500ms里有刷新状态时，不刷新。

Log: 优化图标刷新
Bug: https://pms.uniontech.com/bug-view-171129.html Influence: dock网络图标
Change-Id: Ibae1c46bdd1638567a5d8e459b2fa79ada6468b3

Co-authored-by: liaohanqin <liaohanqin@uniontech.com>