### PR TITLE
fix: 修复WiFi频段单位错误问题

### DIFF
--- a/src/networkdetails.cpp
+++ b/src/networkdetails.cpp
@@ -106,7 +106,7 @@ void NetworkDetails::updateData(const QJsonObject &info)
     if (isWireless || isHotspot) {
         // 频段
         const QString &band = hotspotInfo.value("Band").toString();
-        QString bandInfo = band == "a" ? "5G" : (band == "bg" ? "2.4G" : "automatic");
+        QString bandInfo = band == "a" ? "5 GHz" : (band == "bg" ? "2.4 GHz" : "automatic");
         appendInfo(tr("Band"), bandInfo);
     }
     if (isHotspot) {


### PR DESCRIPTION
2.4G -> 2.4 GHz;5G -> 5 GHz

Log: 修复WiFi频段单位错误问题
Bug: https://pms.uniontech.com/bug-view-176467.html
Influence: WIFI频段
Change-Id: If297d1fdb13846abe910193a9b94235e4db5ad28