### PR TITLE
fix: 要求输入密码时任务栏先响应界面显示再显示密码输入框

### DIFF
--- a/common-plugin/networkdialog.cpp
+++ b/common-plugin/networkdialog.cpp
@@ -71,7 +71,10 @@ void NetworkDialog::setConnectWireless(const QString &dev, const QString &ssid, 
     m_connectDev = dev;
     m_connectSsid = ssid;
     Q_EMIT requestShow();
-    m_panel->passwordError(dev, ssid, wait);
+    // 先响应requestShow将界面显示后再显示密码输入框，否则输入框无焦点
+    QTimer::singleShot(100, this, [ = ]{
+        m_panel->passwordError(dev, ssid, wait);
+    });
 }
 
 void NetworkDialog::newConnectionHandler()


### PR DESCRIPTION
要求输入密码时任务栏先响应界面显示再显示密码输入框

Log: 修复控制中心连接点击加密wifi唤起任务栏的网络面板中对应SSID密码框中无光标问题
Bug: https://pms.uniontech.com/bug-view-172773.html
Influence: 要求输入密码时密码框有焦点