### PR TITLE
fix: wifi页面再点击一下后隐藏,再点击则显示

### DIFF
--- a/dss-network-plugin/dockpopupwindow.cpp
+++ b/dss-network-plugin/dockpopupwindow.cpp
@@ -19,6 +19,8 @@ DockPopupWindow::DockPopupWindow(QWidget *parent)
     , m_model(false)
     , m_regionInter(new DRegionMonitor(this))
     , m_enableMouseRelease(true)
+    , m_timer(new QTimer)
+    , m_isVisible(isVisible())
 {
     setMargin(0);
     m_wmHelper = DWindowManagerHelper::instance();
@@ -36,6 +38,11 @@ DockPopupWindow::DockPopupWindow(QWidget *parent)
 
     connect(m_wmHelper, &DWindowManagerHelper::hasCompositeChanged, this, &DockPopupWindow::compositeChanged);
     connect(m_regionInter, &DRegionMonitor::buttonRelease, this, &DockPopupWindow::onGlobMouseRelease);
+
+    m_timer->start(500);
+    connect(m_timer, &QTimer::timeout, this, [this] {
+        m_isVisible = isVisible();
+    });
 }
 
 DockPopupWindow::~DockPopupWindow()
@@ -61,6 +68,23 @@ void DockPopupWindow::setContent(QWidget *content)
         setAccessibleName(content->objectName() + "-popup");
 
     DArrowRectangle::setContent(content);
+}
+
+bool DockPopupWindow::getIsVisible()
+{
+    return m_isVisible;
+}
+
+void DockPopupWindow::setTimerInterval(int msec)
+{
+    if (!m_timer) {
+        return ;
+    }
+    if (msec == -1) {
+        m_timer->stop();
+    } else {
+        m_timer->start(msec);
+    }
 }
 
 void DockPopupWindow::show(const QPoint &pos, const bool model)

--- a/dss-network-plugin/dockpopupwindow.h
+++ b/dss-network-plugin/dockpopupwindow.h
@@ -23,6 +23,8 @@ public:
     bool model() const;
 
     void setContent(QWidget *content);
+    bool getIsVisible();
+    void setTimerInterval(int msec);
 
 public slots:
     void show(const QPoint &pos, const bool model = false);
@@ -55,6 +57,8 @@ private:
     DRegionMonitor *m_regionInter;
     DWindowManagerHelper *m_wmHelper;
     bool m_enableMouseRelease;
+    QTimer *m_timer;
+    bool m_isVisible;
 };
 
 #endif // DOCKPOPUPWINDOW_H

--- a/dss-network-plugin/network_module.cpp
+++ b/dss-network-plugin/network_module.cpp
@@ -117,6 +117,11 @@ public:
         }
     }
 
+    QList<QPair<QPointer<NETWORKPLUGIN_NAMESPACE::TrayIcon>, QPointer<DockPopupWindow>>> getApplets()
+    {
+        return m_applets;
+    }
+
 protected:
     // qApp的事件较多，固单独一个类监听其事件
     bool eventFilter(QObject *watched, QEvent *e) override
@@ -187,9 +192,24 @@ NetworkModule::NetworkModule(QObject *parent)
 QWidget *NetworkModule::content()
 {
     int msec = QTime::currentTime().msecsSinceStartOfDay();
+    static bool isPopupDisplay = false;
     if (!m_popupAppletManager->popupShown() && abs(msec - m_clickTime) > 200) {
         m_clickTime = msec;
-        m_popupAppletManager->showPopupApplet();
+        QList<QPair<QPointer<NETWORKPLUGIN_NAMESPACE::TrayIcon>, QPointer<DockPopupWindow>>> list = m_popupAppletManager->getApplets();
+        for (auto &&it : list) {
+            if (it.first->isVisible()) {
+                if (it.second.isNull()) {
+                    QWidget *pWidget = it.first->window();
+                    it.second = new DockPopupWindow(pWidget);
+                }
+            }
+            isPopupDisplay = it.second->getIsVisible();
+            if (isPopupDisplay) {
+                m_popupAppletManager->hidePopup();
+            } else {
+                m_popupAppletManager->showPopupApplet();
+            }
+        }
     }
     return nullptr;
 }


### PR DESCRIPTION
当前状态是单机一次不会隐藏,需要双击
修改后如果将鼠标移到外面,再点击一次无法立即唤出wifi页面
使用定时器可以很大概率避免该问题,但是还有有几率出现无法隐藏/显示完美切换

Log:
Bug: https://pms.uniontech.com/bug-view-175907.html
Influence: wifi页面切换
Change-Id: I4c20e6de1347380132cb92de83ad1a2392383e2c