### PR TITLE
fix: 连接监听"com.deepin.system.Network"的"DeviceEnabled"属性改变信号

### DIFF
--- a/src/realize/devicemanagerrealize.h
+++ b/src/realize/devicemanagerrealize.h
@@ -86,6 +86,7 @@ private slots:
     void onWiredConnectionChanged();
     void onWirelessConnectionChanged();
     void onStatusChanged(NetworkManager::Device::State newstate, NetworkManager::Device::State oldstate, NetworkManager::Device::StateChangeReason reason);
+    void onDeviceEnabledChanged(QDBusObjectPath path, bool enabled);
 
 private:
     QSharedPointer<Device> m_wDevice;


### PR DESCRIPTION
连接监听"com.deepin.system.Network"的"DeviceEnabled"属性改变信号,及时刷新网络列表界面

Log: 修复登录界面上关闭无线网络时网络列表不会及时清空的问题
Bug: https://pms.uniontech.com/bug-view-179753.html
Influence: 关闭网络时及时清空无线网络列表