### PR TITLE
fix: 保存最后一次设置的代理类型

### DIFF
--- a/config/org.deepin.dde.network.json
+++ b/config/org.deepin.dde.network.json
@@ -21,7 +21,7 @@
             "permissions": "readwrite",
             "visibility": "public"
         },
-	 "networkAirplaneMode": {
+        "networkAirplaneMode": {
             "value": false,
             "serial": 0,
             "flags": [],
@@ -30,6 +30,16 @@
             "description": "控制中心-网络模块是否显示飞行模式页面，默认不显示。",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "lastProxyMethod": {
+               "value": "manual",
+               "serial": 0,
+               "flags": [],
+               "name": "LastProxyMethod",
+               "name[zh_CN]": "最后一次设置的代理类型",
+               "description": "控制中心-网络模块最后一次设置的代理类型，默认手动。",
+               "permissions": "readwrite",
+               "visibility": "private"
         }
     }
 }

--- a/dcc-network-plugin/proxypage.cpp
+++ b/dcc-network-plugin/proxypage.cpp
@@ -41,6 +41,7 @@ ProxyPage::ProxyPage(QWidget *parent)
     : QWidget(parent)
     , m_autoWidget(new TranslucentFrame(this))
     , m_buttonTuple(new ButtonTuple(ButtonTuple::Save, this))
+    , m_dconfig(DConfig::create("org.deepin.dde.network", "org.deepin.dde.network", QString(), this))
 {
     ContentWidget *conentwidget = new ContentWidget(this);
     conentwidget->setAccessibleName("ProxyPage_ContentWidget");
@@ -182,8 +183,8 @@ ProxyPage::ProxyPage(QWidget *parent)
     connect(m_proxySwitch, &SwitchWidget::checkedChanged, m_proxyTypeBox, [ = ](const bool checked) {
         m_buttonTuple->setEnabled(checked);
         if (checked) {
-            // 打开代理默认手动
-            onProxyMethodChanged(ProxyMethod::Manual);
+            // 根据最后设置的代理类型重置界面
+            onProxyMethodChanged(getProxyMethod());
         } else {
             // 关闭代理
             proxyController->setProxyMethod(ProxyMethod::None);
@@ -288,9 +289,13 @@ void ProxyPage::applySettings()
         proxyController->setProxy(SysProxyType::Socks, m_socksAddr->text(), m_socksPort->text());
         proxyController->setProxyIgnoreHosts(m_ignoreList->toPlainText());
         proxyController->setProxyMethod(ProxyMethod::Manual);
+        // 保存上一次设置的代理类型
+        saveProxyMethod("manual");
     } else if (m_proxyTypeBox->comboBox()->currentIndex() == ProxyMethodList.indexOf(AUTO)) {
         proxyController->setAutoProxy(m_autoUrl->text());
         proxyController->setProxyMethod(ProxyMethod::Auto);
+        // 保存上一次设置的代理类型
+        saveProxyMethod("auto");
     }
 }
 
@@ -368,4 +373,23 @@ void ProxyPage::clearLineEditWidgetFocus()
 
     if (m_ignoreList)
         m_ignoreList->clearFocus();
+}
+
+void ProxyPage::saveProxyMethod(const QString &method)
+{
+    if (m_dconfig && m_dconfig->isValid()) {
+        m_dconfig->setValue("lastProxyMethod", method);
+    }
+}
+
+ProxyMethod ProxyPage::getProxyMethod()
+{
+    if (m_dconfig && m_dconfig->isValid()) {
+        const QString method = m_dconfig->value("lastProxyMethod", "manual").toString();
+
+        if (method == "auto")
+            return ProxyMethod::Auto;
+    }
+
+    return ProxyMethod::Manual;
 }

--- a/dcc-network-plugin/proxypage.h
+++ b/dcc-network-plugin/proxypage.h
@@ -8,6 +8,10 @@
 #include "widgets/contentwidget.h"
 #include "interface/namespace.h"
 
+#include <DConfig>
+
+DCORE_USE_NAMESPACE
+
 namespace dde {
   namespace network {
     class SysProxyConfig;
@@ -56,6 +60,9 @@ private:
 
     void clearLineEditWidgetFocus();
 
+    void saveProxyMethod(const QString &method);
+    ProxyMethod getProxyMethod();
+
 private:
     QWidget *m_autoWidget;
     QWidget *m_manualWidget;
@@ -75,6 +82,8 @@ private:
 
     SwitchWidget* m_proxySwitch;
     ComboxWidget* m_proxyTypeBox;
+
+    DConfig *m_dconfig;
 };
 
 #endif // PROXYPAGE_H


### PR DESCRIPTION
关闭系统代理后，代理类型设置为none,再次打开时无法区分最后设置的代理类型，再次打开代理时全部默认为手动。 添加dconfig配置记录最后一次设置的代理类型，再次打开代理时根据保存的数据设置默认界面

Log: 修复代理类型选择自动后关闭系统代理开关后打开，代理类型为手动的问题
Bug: https://pms.uniontech.com/bug-view-179801.html
Influence: 打开系统代理时自动切换到最后一次设置的代理类型