### PR TITLE
fix: 登录/锁屏点击网络图标崩溃

### DIFF
--- a/dss-network-plugin/network_module.cpp
+++ b/dss-network-plugin/network_module.cpp
@@ -114,6 +114,14 @@ public:
         }
         if (trayIcon) {
             m_applets.append({ QPointer<TrayIcon>(trayIcon), QPointer<DockPopupWindow>(nullptr) });
+            connect(trayIcon, &QObject::destroyed, this, [trayIcon, this] {
+                for (auto pair : m_applets) {
+                    if (pair.first.data() == trayIcon) {
+                        m_applets.removeAll(pair);
+                        break;
+                    }
+                }
+            });
         }
     }
 


### PR DESCRIPTION
原因:访问了空指针
处理方案: 指针析构后从list中移除

Log:
Bug: https://pms.uniontech.com/bug-view-180475.html
Influence: 登录、锁屏点击网络图标
Change-Id: I4871cbbb442a3a9a3c9105d0ee9785297a954e0f