### PR TITLE
fix: 登录界面崩溃

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.user
 build/
 .cache/
+.vscode/

--- a/src/ipconfilctchecker.cpp
+++ b/src/ipconfilctchecker.cpp
@@ -236,7 +236,7 @@ DeviceIPChecker::DeviceIPChecker(NetworkDeviceBase *device, NetworkInter *netInt
             emit ipConflictCheck(m_ipV4);
         } else {
             if ((m_count++ % 2) == 0) {
-                if (m_device->deviceStatus() == DeviceStatus::Activated && m_device->connectivity() == Connectivity::Limited) {
+                if (!m_device.isNull() && m_device->deviceStatus() == DeviceStatus::Activated && m_device->connectivity() == Connectivity::Limited) {
                     PRINT_INFO_MESSAGE(QString("[off] limit check ip conflict:%1").arg(m_ipV4.join(",")));
                     emit ipConflictCheck(m_ipV4);
                     return;

--- a/src/ipconfilctchecker.h
+++ b/src/ipconfilctchecker.h
@@ -5,10 +5,11 @@
 #ifndef IPCONFILCTCHECKER_H
 #define IPCONFILCTCHECKER_H
 
-#include <QObject>
 #include "netutils.h"
-
 #include "networkconst.h"
+
+#include <QObject>
+#include <QPointer>
 
 namespace dde {
 namespace network {
@@ -64,7 +65,7 @@ public:
     bool ipConflicted();
 
 private:
-    NetworkDeviceBase *m_device;
+    QPointer<NetworkDeviceBase> m_device;
     NetworkInter *m_networkInter;
     QStringList m_ipV4;
     QString m_macAddress;


### PR DESCRIPTION
原因：检查ip冲突时使用了悬空指针
方案：使用QPointer并增加判空

Log:
Bug: https://pms.uniontech.com/bug-view-180831.html
Influence: 登录、锁屏界面待机休眠唤醒
Change-Id: Ifb0f6697fb11babc4bc7d46369f8df1b78512824