### PR TITLE
fix: 修复dock栏无法自动回连问题

### DIFF
--- a/common-plugin/networkdialog/networkpanel.cpp
+++ b/common-plugin/networkdialog/networkpanel.cpp
@@ -651,7 +651,7 @@ void NetworkPanel::onClickListView(const QModelIndex &index)
     NetItem *newSelectItem = m_items.at(index.row());
     if (newSelectItem != oldSelectItem && oldSelectItem) {
         WirelessItem *item = static_cast<WirelessItem *>(oldSelectItem);
-        item->expandWidget(WirelessItem::Hide); // 选择切换时隐藏输入框
+        item->expandWidget(WirelessItem::Hide, false); // 选择切换时隐藏输入框
     }
     switch (type) {
     case WirelessHiddenViewItem:


### PR DESCRIPTION
主动断开了网络导致无法自动回连

Log: 修复dock栏无法自动回连问题
Bug: https://pms.uniontech.com/bug-view-181203.html
Influence: 网络
Change-Id: I11450cfaa7e52b807a07198c461d6d8c7aa95a68