### PR TITLE
fix: 修复dock栏无法自动回连问题

### DIFF
--- a/dde-network-dialog/networkpanel.cpp
+++ b/dde-network-dialog/networkpanel.cpp
@@ -632,7 +632,7 @@ void NetworkPanel::onClickListView(const QModelIndex &index)
     NetItem *newSelectItem = m_items.at(index.row());
     if (newSelectItem != oldSelectItem && oldSelectItem) {
         WirelessItem *item = static_cast<WirelessItem *>(oldSelectItem);
-        item->expandWidget(WirelessItem::Hide); // 选择切换时隐藏输入框
+        item->expandWidget(WirelessItem::Hide, false); // 选择切换时隐藏输入框
     }
     switch (type) {
     case WirelessHiddenViewItem:


### PR DESCRIPTION
主动断开了网络导致无法自动回连

Log: 修复dock栏无法自动回连问题
Bug: https://pms.uniontech.com/bug-view-181203.html
Influence: 网络
Change-Id: I08ced4aa92587c2f3f750895a19887361add604c