### PR TITLE
fix: Control Center not automatically scanning for APs

### DIFF
--- a/dcc-network-plugin/window/wirelessmodule.cpp
+++ b/dcc-network-plugin/window/wirelessmodule.cpp
@@ -114,6 +114,14 @@ void WirelessModule::initWirelessList(DListView *lvAP)
     });
 }
 
+void WirelessModule::active() {
+    PageModule::active();
+
+    if (m_device->isEnabled()) {
+        m_device->scanNetwork();
+    }
+}
+
 void WirelessModule::onNameChanged(const QString &name)
 {
     QString tmp;

--- a/dcc-network-plugin/window/wirelessmodule.h
+++ b/dcc-network-plugin/window/wirelessmodule.h
@@ -26,6 +26,9 @@ class WirelessModule : public DCC_NAMESPACE::PageModule
 public:
     explicit WirelessModule(dde::network::WirelessDevice *dev, QObject *parent = nullptr);
 
+public Q_SLOTS:
+    virtual void active() override;
+
 private Q_SLOTS:
     void onNetworkAdapterChanged(bool checked);
     void onApWidgetEditRequested(dde::network::AccessPoints *ap, QWidget *parent);


### PR DESCRIPTION
When opening the page, if the wireless network is
turned on, then scan.
Fixes linuxdeepin/developer-center#3761