### PR TITLE
fix(dcc-network-plugin): 修改在多块无线网卡绑定到其他设备MAC时无法开启热点问题

### DIFF
--- a/dcc-network-plugin/window/sections/wirelesssection.cpp
+++ b/dcc-network-plugin/window/sections/wirelesssection.cpp
@@ -25,17 +25,19 @@ using namespace DCC_NAMESPACE;
 using namespace NetworkManager;
 using namespace dcc::network;
 
-WirelessSection::WirelessSection(WirelessSetting::Ptr wiredSetting, bool isHotSpot, QFrame *parent)
+WirelessSection::WirelessSection(ConnectionSettings::Ptr connSettings, WirelessSetting::Ptr wiredSetting, QString devPath, bool isHotSpot, QFrame *parent)
     : AbstractSection(tr("WLAN"), parent)
     , m_apSsid(new LineEditWidget(this))
     , m_deviceMacLine(new ComboxWidget(this))
     , m_customMtuSwitch(new SwitchWidget(this))
     , m_customMtu(new SpinBoxWidget(this))
+    , m_connSettings(connSettings)
     , m_wirelessSetting(wiredSetting)
 {
     // get the macAddress list from all wireless devices
     for (auto device : networkInterfaces()) {
-        if (device->type() != Device::Type::Wifi)
+        if (device->type() != Device::Type::Wifi
+            || (!devPath.isEmpty() && devPath != "/" && device->uni() != devPath))
             continue;
 
         WirelessDevice::Ptr wDevice = device.staticCast<WirelessDevice>();
@@ -45,10 +47,10 @@ WirelessSection::WirelessSection(WirelessSetting::Ptr wiredSetting, bool isHotSp
 
         /* Alt:  permanentHardwareAddress to get real hardware address which is connot be changed */
         const QString &macStr = wDevice->permanentHardwareAddress() + " (" + wDevice->interfaceName() + ")";
-        m_macStrMap.insert(macStr, wDevice->permanentHardwareAddress().remove(":"));
+        m_macStrMap.insert(macStr, { wDevice->permanentHardwareAddress().remove(":"), wDevice->interfaceName() });
     }
 
-    m_macStrMap.insert(tr("Not Bind"), NotBindValue);
+    m_macStrMap.insert(tr("Not Bind"), { NotBindValue, QString() });
 
     // "^([0-9A-Fa-f]{2}[:-\\.]){5}([0-9A-Fa-f]{2})$"
     m_macAddrRegExp = QRegExp("^([0-9A-Fa-f]{2}[:]){5}([0-9A-Fa-f]{2})$");
@@ -81,7 +83,8 @@ void WirelessSection::saveSettings()
 {
     m_wirelessSetting->setSsid(m_apSsid->text().toUtf8());
 
-    QString hwAddr = m_macStrMap.value(m_deviceMacComboBox->currentText());
+    const QPair<QString, QString> &pair = m_macStrMap.value(m_deviceMacComboBox->currentText());
+    QString hwAddr = pair.first;
     if (hwAddr == NotBindValue)
         hwAddr.clear();
 
@@ -93,6 +96,8 @@ void WirelessSection::saveSettings()
     m_wirelessSetting->setMtu(m_customMtuSwitch->checked() ? static_cast<unsigned int>(m_customMtu->spinBox()->value()) : 0);
 
     m_wirelessSetting->setInitialized(true);
+    if (!hwAddr.isEmpty())
+        m_connSettings->setInterfaceName(pair.second);
 }
 
 void WirelessSection::setSsidEditable(const bool editable)
@@ -126,12 +131,14 @@ void WirelessSection::initUI()
     m_deviceMacLine->setTitle(tr("Device MAC Addr"));
     m_deviceMacComboBox = m_deviceMacLine->comboBox();
     for (const QString &key : m_macStrMap.keys())
-        m_deviceMacComboBox->addItem(key, m_macStrMap.value(key));
+        m_deviceMacComboBox->addItem(key, m_macStrMap.value(key).first);
 
     // get the macAddress from Settings
     const QString &macAddr = QString(m_wirelessSetting->macAddress().toHex()).toUpper();
 
-    if (m_macStrMap.values().contains(macAddr))
+    if (std::any_of(m_macStrMap.cbegin(), m_macStrMap.cend(), [macAddr](const QPair<QString, QString> &it) {
+            return it.first == macAddr;
+        }))
         m_deviceMacComboBox->setCurrentIndex(m_deviceMacComboBox->findData(macAddr));
     else
         m_deviceMacComboBox->setCurrentIndex(m_deviceMacComboBox->findData(NotBindValue));

--- a/dcc-network-plugin/window/sections/wirelesssection.cpp
+++ b/dcc-network-plugin/window/sections/wirelesssection.cpp
@@ -25,7 +25,7 @@ using namespace DCC_NAMESPACE;
 using namespace NetworkManager;
 using namespace dcc::network;
 
-WirelessSection::WirelessSection(ConnectionSettings::Ptr connSettings, WirelessSetting::Ptr wiredSetting, QString devPath, bool isHotSpot, QFrame *parent)
+WirelessSection::WirelessSection(ConnectionSettings::Ptr connSettings, WirelessSetting::Ptr wiredSetting, const QString &devPath, bool isHotSpot, QFrame *parent)
     : AbstractSection(tr("WLAN"), parent)
     , m_apSsid(new LineEditWidget(this))
     , m_deviceMacLine(new ComboxWidget(this))

--- a/dcc-network-plugin/window/sections/wirelesssection.h
+++ b/dcc-network-plugin/window/sections/wirelesssection.h
@@ -31,7 +31,7 @@ class WirelessSection : public AbstractSection
     Q_OBJECT
 
 public:
-    explicit WirelessSection(ConnectionSettings::Ptr connSettings, WirelessSetting::Ptr wiredSetting, QString devPath, bool isHotSpot = false, QFrame *parent = nullptr);
+    explicit WirelessSection(ConnectionSettings::Ptr connSettings, WirelessSetting::Ptr wiredSetting, const QString &devPath, bool isHotSpot = false, QFrame *parent = nullptr);
     virtual ~WirelessSection() Q_DECL_OVERRIDE;
 
     bool allInputValid() Q_DECL_OVERRIDE;

--- a/dcc-network-plugin/window/sections/wirelesssection.h
+++ b/dcc-network-plugin/window/sections/wirelesssection.h
@@ -14,12 +14,15 @@ class LineEditWidget;
 class ComboxWidget;
 class SwitchWidget;
 }
+#include <networkmanagerqt/connectionsettings.h>
 
 namespace dcc {
 namespace network {
 class SpinBoxWidget;
 }
 }
+
+using namespace NetworkManager;
 
 class QComboBox;
 
@@ -28,7 +31,7 @@ class WirelessSection : public AbstractSection
     Q_OBJECT
 
 public:
-    explicit WirelessSection(NetworkManager::WirelessSetting::Ptr wiredSetting, bool isHotSpot = false, QFrame *parent = nullptr);
+    explicit WirelessSection(ConnectionSettings::Ptr connSettings, WirelessSetting::Ptr wiredSetting, QString devPath, bool isHotSpot = false, QFrame *parent = nullptr);
     virtual ~WirelessSection() Q_DECL_OVERRIDE;
 
     bool allInputValid() Q_DECL_OVERRIDE;
@@ -56,10 +59,11 @@ private:
     DCC_NAMESPACE::SwitchWidget *m_customMtuSwitch;
     dcc::network::SpinBoxWidget *m_customMtu;
 
-    NetworkManager::WirelessSetting::Ptr m_wirelessSetting;
+    ConnectionSettings::Ptr m_connSettings;
+    WirelessSetting::Ptr m_wirelessSetting;
 
     QRegExp m_macAddrRegExp;
-    QMap<QString, QString> m_macStrMap;
+    QMap<QString, QPair<QString, QString>> m_macStrMap;
 };
 
 #endif /* WIRELESSSECTION_H */

--- a/dcc-network-plugin/window/settings/abstractsettings.cpp
+++ b/dcc-network-plugin/window/settings/abstractsettings.cpp
@@ -64,6 +64,9 @@ bool AbstractSettings::isAutoConnect()
 
 void AbstractSettings::resetConnectionInterfaceName()
 {
+    if (!m_connSettings->interfaceName().isEmpty())
+        return;
+
     if (ConnectionEditPage::devicePath().isEmpty() || clearInterfaceName()) {
         m_connSettings->setInterfaceName(QString());
         return;

--- a/dcc-network-plugin/window/settings/hotspotsettings.cpp
+++ b/dcc-network-plugin/window/settings/hotspotsettings.cpp
@@ -6,6 +6,7 @@
 #include "sections/generichotspotsection.h"
 #include "sections/secrethotspotsection.h"
 #include "sections/wirelesssection.h"
+#include "editpage/connectioneditpage.h"
 
 #include <QVBoxLayout>
 
@@ -32,7 +33,7 @@ void HotspotSettings::initSections()
 
     SecretHotspotSection *secretHotspotSection = new SecretHotspotSection(m_connSettings->setting(Setting::SettingType::WirelessSecurity).staticCast<WirelessSecuritySetting>());
 
-    WirelessSection *wirelessSection = new WirelessSection(wirelessSetting, true);
+    WirelessSection *wirelessSection = new WirelessSection(m_connSettings, wirelessSetting, ConnectionEditPage::devicePath(), true);
 
     connect(genericSection, &GenericHotspotSection::editClicked, this, &HotspotSettings::anyEditClicked);
     connect(secretHotspotSection, &GenericHotspotSection::editClicked, this, &HotspotSettings::anyEditClicked);

--- a/dcc-network-plugin/window/settings/wirelesssettings.cpp
+++ b/dcc-network-plugin/window/settings/wirelesssettings.cpp
@@ -9,6 +9,7 @@
 #include "sections/dnssection.h"
 #include "sections/wirelesssection.h"
 //#include "window/gsettingwatcher.h"
+#include "editpage/connectioneditpage.h"
 
 #include <widgets/switchwidget.h>
 
@@ -41,7 +42,7 @@ void WirelessSettings::initSections()
 
     DNSSection *dnsSection = new DNSSection(m_connSettings);
 
-    WirelessSection *wirelessSection = new WirelessSection(m_connSettings->setting(Setting::SettingType::Wireless).staticCast<WirelessSetting>());
+    WirelessSection *wirelessSection = new WirelessSection(m_connSettings, m_connSettings->setting(Setting::SettingType::Wireless).staticCast<WirelessSetting>(), ConnectionEditPage::devicePath());
     // we need enable ssid text edit since it is a hidden wifi edit page if ssid is empty
     if (!wirelessSection->ssid().isEmpty())
         wirelessSection->setSsidEditable(false);


### PR DESCRIPTION
设置项里InterfaceName与对应的MAC地址不匹配
修改为InterfaceName在绑定MAC地址时同时设置，无线网卡改为只能绑定当前网卡MAC地址

It lossed when merge v23 in 5c8817ca4058c0c6cd9150be8842a2e02ae61cd5 
Log:
Issue: https://github.com/linuxdeepin/developer-center/issues/3947 
Bug: https://pms.uniontech.com/bug-view-148023.html Influence: 控制中心-网络-创建热点
Change-Id: If878cec66843ec9c5dd07382d6b5171f5771b8ce