### PR TITLE
fix: add backgroundcolor to the line proxy type

### DIFF
--- a/dcc-network-plugin/window/sysproxymodule.cpp
+++ b/dcc-network-plugin/window/sysproxymodule.cpp
@@ -68,6 +68,7 @@ SysProxyModule::SysProxyModule(QObject *parent)
     m_modules.append(new WidgetModule<ComboxWidget>("system_proxy_box", tr("System Proxy"), [this](ComboxWidget *proxyTypeBox) {
         m_proxyTypeBox = proxyTypeBox;
         proxyTypeBox->setTitle(tr("Proxy Type"));
+        proxyTypeBox->addBackground();
         proxyTypeBox->comboBox()->addItems(m_ProxyMethodList);
         auto updateBox = [proxyTypeBox]() {
             ProxyMethod method = NetworkController::instance()->proxyController()->proxyMethod();


### PR DESCRIPTION
Problem: the line "proxy type" of the page "system proxy" doesn't have grey backgroundcolor like other lines.
Solution: I used addBackground() to make this line the same like others
Issue: #141 
Log:  add grey backgroundcolor to the line proxy type of page system proxy.