### PR TITLE
fix: CMakeLists.txt的HOMEPAGE_URL值错误

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(VERSION "2.0.4" CACHE STRING "define project version")
 project(dde-network-core
   VERSION ${VERSION}
   DESCRIPTION "DDE Network Core"
-  HOMEPAGE_URL "https://github.com/linuxdeepin/dde-network-core9"
+  HOMEPAGE_URL "https://github.com/linuxdeepin/dde-network-core"
   LANGUAGES CXX C
 )
 


### PR DESCRIPTION
    CMakeLists.txt的HOMEPAGE_URL值末尾多了一个字符9。

Log: 修改了CMakeLists.txt的HOMEPAGE_URL值