### PR TITLE
fix: 修复了新增个人热点的弹窗名称与安全之间的间隔过大的问题

### DIFF
--- a/dcc-network-plugin/window/sections/secrethotspotsection.cpp
+++ b/dcc-network-plugin/window/sections/secrethotspotsection.cpp
@@ -22,7 +22,7 @@ static const QList<WirelessSecuritySetting::KeyMgmt> KeyMgmtList {
 };
 
 SecretHotspotSection::SecretHotspotSection(WirelessSecuritySetting::Ptr wsSeting, QFrame *parent)
-    : AbstractSection(parent)
+    : AbstractSection(tr("Security"), parent)
     , m_keyMgmtChooser(new ComboxWidget(this))
     , m_passwdEdit(new LineEditWidget(true))
     , m_currentKeyMgmt(WirelessSecuritySetting::KeyMgmt::WpaNone)


### PR DESCRIPTION
新增个人热点的弹窗是3个并列的Widget，分别是genericSection、secretHotspotSection、wirelessSection

其中secretHotspotSection即为安全选项，这个Widget没有标题，修改后给secretHotspotSection一个标题，使得3个Widget格式一致，间隔也一致。

Issue: #141 

Log: 修复了新增个人热点的弹窗名称与安全之间的间隔过大的问题

修改前效果：

![原来的效果](https://user-images.githubusercontent.com/43291769/232477187-9d154ba8-c993-4027-9190-cdf481f2d71c.png)

修改后效果：

![修改后效果](https://user-images.githubusercontent.com/43291769/232477218-79b900ae-20da-46ff-a3a3-af359a6d7452.png)
