### PR TITLE
fix: 修复了内容区没有居中于弹窗的问题

### DIFF
--- a/dcc-network-plugin/window/editpage/connectioneditpage.cpp
+++ b/dcc-network-plugin/window/editpage/connectioneditpage.cpp
@@ -88,6 +88,7 @@ void ConnectionEditPage::initUI()
     QScrollArea * area = new QScrollArea;
     area->setFrameShape(QFrame::NoFrame);
     area->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    area->setAlignment(Qt::AlignHCenter);
     area->setWidgetResizable(true);
     QWidget *w = new QWidget();
     w->setLayout(m_settingsLayout);


### PR DESCRIPTION
隐藏了滚动条，修复了无线网络、有线网络（添加网络配置）、DSL（创建PPPoE连接）、VPN（添加VPN）一共四个页面的内容区没有居中于弹窗的问题。

修复的具体内容：
内容区的布局设置了横向居中对齐，最终使得内容区实现了居中效果。

Issue: #141

Log: 修复了内容区没有居中于弹窗的问题

修改前页面:
![修改前](https://user-images.githubusercontent.com/62835480/233573485-5821f8dc-0252-40a3-b379-655cf076988e.png)

修改后页面:
![%SY%$U2J4HPBSTY7MJBIX%0](https://user-images.githubusercontent.com/62835480/233592525-73729bd1-4324-4da5-8077-e4919d5fa5ca.png)

![TQD$KGZ0GZF388{F{4QOMGQ](https://user-images.githubusercontent.com/62835480/233592261-4193a370-f8a9-4516-ba6c-2e6b2a244469.png)
