### PR TITLE
fix: 修复了新建vpn和无线网络弹窗中导出和保存的button与弹窗间距不一致的问题

### DIFF
--- a/dcc-network-plugin/window/editpage/connectioneditpage.cpp
+++ b/dcc-network-plugin/window/editpage/connectioneditpage.cpp
@@ -456,7 +456,10 @@ int ConnectionEditPage::connectionSuffixNum(const QString &matchConnName)
 
 void ConnectionEditPage::addHeaderButton(QPushButton *button)
 {
-    m_mainLayout->insertWidget(m_mainLayout->indexOf(m_buttonTuple_conn) + 1, button);
+    QVBoxLayout *headerButtonLayout = new QVBoxLayout();
+    headerButtonLayout->addWidget(button);
+    headerButtonLayout->setContentsMargins(10, 0, 10, 0);
+    m_mainLayout->insertLayout(m_mainLayout->indexOf(m_buttonTuple_conn) + 1, headerButtonLayout);
 }
 
 bool ConnectionEditPage::eventFilter(QObject *obj, QEvent *event)


### PR DESCRIPTION
修复了新建vpn和无线网络弹窗中导出与取消、保存的button与弹窗间距不一致的问题。

Issue: #141

Log: 修复了新建vpn和无线网络弹窗中导出和保存的button与弹窗间距不一致的问题

实现方式：
参照取消和保存按钮组的布局方式，给导出按钮也增加了外层的布局，并设置了与取消和保存按钮同样的布局以及左右边距，使得上下按钮对齐了。

修复前：
![8Y{R@IL_`C7J3MN18C$3RB](https://user-images.githubusercontent.com/131222563/233584284-82d60f46-50bd-40ec-9931-685013df8f64.png)

修复后：
![@ {(US60U4$FX3`F`_KYFN9](https://user-images.githubusercontent.com/131222563/233584411-d899802e-4301-494c-b13b-b67527c941e0.png)

