### PR TITLE
fix: App crashed running in debug QT

### DIFF
--- a/dcc-network-plugin/CMakeLists.txt
+++ b/dcc-network-plugin/CMakeLists.txt
@@ -89,4 +89,4 @@ set(CMAKE_INSTALL_PREFIX "/usr")
 install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/dde-control-center/modules)
 
 # 安装 .qm 文件
-install(FILES ${QM_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${PLUGIN_NAME}/translations)
+install(FILES ${QM_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dde-control-center/translations)

--- a/dcc-network-plugin/window/dccnetworkmodule.cpp
+++ b/dcc-network-plugin/window/dccnetworkmodule.cpp
@@ -16,7 +16,6 @@
 #include <QMap>
 #include <QEvent>
 #include <QTimer>
-#include <QTranslator>
 #include <QCoreApplication>
 
 #include <networkcontroller.h>
@@ -161,17 +160,13 @@ DccNetworkPlugin::~DccNetworkPlugin()
 
 QString DccNetworkPlugin::name() const
 {
-    return QStringLiteral("network");
+    return QStringLiteral("dcc-network-plugin");
 }
 
 ModuleObject *DccNetworkPlugin::module()
 {
     if (m_moduleRoot)
         return m_moduleRoot;
-
-    QTranslator * translator = new QTranslator(this);
-    translator->load("/usr/share/dcc-network-plugin/translations/dcc-network-plugin_" + QLocale::system().name());
-    qApp->installTranslator(translator);
 
     m_moduleRoot = new NetworkModule;
     return m_moduleRoot;

--- a/debian/dcc-network-plugin.install
+++ b/debian/dcc-network-plugin.install
@@ -1,2 +1,2 @@
 usr/lib/*/dde-control-center/modules
-usr/share/dcc-network-plugin/translations
+usr/share/dde-control-center/translations

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -7,6 +7,7 @@
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QTranslator>
+#include <DGuiApplicationHelper>
 
 #include "dccplugintestwidget.h"
 
@@ -19,6 +20,9 @@ int main(int argc, char *argv[])
     QTranslator t;
     if (t.load(":/qm/network_cn_qm"))
         app.installTranslator(&t);
+    Dtk::Gui::DGuiApplicationHelper::loadTranslator("dcc-network-plugin",
+                                                    {app.applicationDirPath() + "/../dcc-network-plugin"},
+                                                    {QLocale::system()});
 
     if (QString(argv[1]) == "dccPlug") {
         DccPluginTestWidget testPluginWidget;


### PR DESCRIPTION
  QTranslater must be installed in main thread.
  We don't load translate, and it's loaded by `dde-control-center`