### PR TITLE
fix: Crashed when exit running in debug qt

### DIFF
--- a/src/ipconfilctchecker.cpp
+++ b/src/ipconfilctchecker.cpp
@@ -39,6 +39,10 @@ IPConfilctChecker::IPConfilctChecker(NetworkProcesser *networkProcesser, const b
 
 IPConfilctChecker::~IPConfilctChecker()
 {
+}
+
+void IPConfilctChecker::release()
+{
     m_thread->quit();
     m_thread->wait();
 }

--- a/src/ipconfilctchecker.h
+++ b/src/ipconfilctchecker.h
@@ -31,6 +31,8 @@ public:
     explicit IPConfilctChecker(NetworkProcesser *networkProcesser, const bool ipChecked, QObject *parent = nullptr);
     ~IPConfilctChecker();
 
+    void release();
+
 private Q_SLOT:
     void onDeviceAdded(QList<NetworkDeviceBase *> devices);
     void onIPConfilct(const QString &ip, const QString &macAddress);

--- a/src/realize/networkinterprocesser.cpp
+++ b/src/realize/networkinterprocesser.cpp
@@ -45,7 +45,8 @@ NetworkInterProcesser::NetworkInterProcesser(bool sync, bool ipCheck, QObject *p
 
 NetworkInterProcesser::~NetworkInterProcesser()
 {
-    delete m_ipChecker;
+    m_ipChecker->release();
+    m_ipChecker->deleteLater();
 }
 
 void NetworkInterProcesser::initNetData(NetworkDBusProxy *networkInt)


### PR DESCRIPTION
  We release QObject by deleteLater instead of delete,
IpConfilctChecker is delete in NetworkInterProcesser, and it's thread is in main thread, but IpConfilctChecker object is moved to QThread, it causes QObject is delete in other thread.