### PR TITLE
fix: Add a missing library link

### DIFF
--- a/dcc-network-plugin/CMakeLists.txt
+++ b/dcc-network-plugin/CMakeLists.txt
@@ -79,6 +79,7 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
     ${KF5_QT_LIBRARIES}
     ${Qt5Network_LIBRARIES}
     ${DCC_WIDGETS_LIBRARIES}
+    ${DCC_INTERFACE_LIBRARIES}
 #    ${DDE-Network-Core_LIBRARIES}
 )
 


### PR DESCRIPTION
Add ${DCC_INTERFACE_LIBRARIES} link for dcc-network-plugin

Log: Need link this library link to fix build on openSUSE