### PR TITLE
fix: crash on exit when running in qt debug ver

### DIFF
--- a/src/realize/networkmanagerprocesser.cpp
+++ b/src/realize/networkmanagerprocesser.cpp
@@ -48,7 +48,8 @@ NetworkManagerProcesser::NetworkManagerProcesser(QObject *parent)
 
 NetworkManagerProcesser::~NetworkManagerProcesser()
 {
-    delete m_ipChecker;
+    m_ipChecker->release();
+    m_ipChecker->deleteLater();
 }
 
 void NetworkManagerProcesser::initConnections()


### PR DESCRIPTION
IPConflictChecker should be deleted in the thread it was created. Do not use "delete", just use deleteLater to emit a signal that will be disposed in the thread created later.

Log: fix crash on exit when running in qt debug version