### PR TITLE
fix: Hotspot can't be connected for Wpa/Wpa2

### DIFF
--- a/dcc-network-plugin/window/sections/secrethotspotsection.cpp
+++ b/dcc-network-plugin/window/sections/secrethotspotsection.cpp
@@ -92,7 +92,7 @@ void SecretHotspotSection::saveSettings()
     case WirelessSecuritySetting::KeyMgmt::WpaPsk: {
         m_wsSetting->setPsk(m_passwdEdit->text());
         m_wsSetting->setPskFlags(NetworkManager::Setting::AgentOwned);
-        m_wsSetting->setProto(QList<NetworkManager::WirelessSecuritySetting::WpaProtocolVersion>{NetworkManager::WirelessSecuritySetting::Wpa,NetworkManager::WirelessSecuritySetting::Rsn});
+        m_wsSetting->setProto(QList<NetworkManager::WirelessSecuritySetting::WpaProtocolVersion>{NetworkManager::WirelessSecuritySetting::Wpa});
         m_wsSetting->setGroup(QList<NetworkManager::WirelessSecuritySetting::WpaEncryptionCapabilities>{NetworkManager::WirelessSecuritySetting::Ccmp});
         m_wsSetting->setPairwise(QList<NetworkManager::WirelessSecuritySetting::WpaEncryptionCapabilities>{NetworkManager::WirelessSecuritySetting::Ccmp});
         break;


### PR DESCRIPTION
  In WPA3-Personal Transition Mode, We change `802-11-wireless-security.proto`
from {`wpa`, rsn} to {wpa}
  In `network-manager` project `src/core/supplicant/nm-supplicant-config.c:908`.
`key_mgmt` will be added `SAE` if `pmf` isn't false, it will works in unsupport `SAE` networkcard.
  We don't use `RSN` wireless-security proto for the Transition Mode.
  TODO: How should we configure it in WPA3-Personal Transition Mode?

Issue: https://github.com/linuxdeepin/developer-center/issues/3732