### PR TITLE
fix: 网络详情与后端不同步 (#107)

### DIFF
--- a/src/realize/networkinterprocesser.cpp
+++ b/src/realize/networkinterprocesser.cpp
@@ -557,11 +557,7 @@ void NetworkInterProcesser::updateNetworkDetails()
         devicePaths << device->path();
     }
 
-    // 删除不在设备列表中的项
-    for (NetworkDetails *detail : m_networkDetails) {
-        if (!devicePaths.contains(detail->devicePath()))
-            m_networkDetails.removeOne(detail);
-    }
+
     // 删除多余的网络详情的数据
     if (m_networkDetails.size() >= m_activeConnectionInfo.size()) {
         for (int i = m_networkDetails.size() - 1; i >= m_activeConnectionInfo.size(); i--) {
@@ -574,9 +570,6 @@ void NetworkInterProcesser::updateNetworkDetails()
     // 遍历网络详情列表，更新内存中的记录
     for (int i = 0; i < m_activeConnectionInfo.size(); i++) {
         QJsonObject activeConnection = m_activeConnectionInfo.at(i).toObject();
-        QString devicePath = activeConnection.value("Device").toString();
-        if (!devicePaths.contains(devicePath))
-            continue;
 
         NetworkDetails *detail = Q_NULLPTR;
         if (i < m_networkDetails.size()) {
@@ -587,6 +580,14 @@ void NetworkInterProcesser::updateNetworkDetails()
         }
 
         detail->updateData(activeConnection);
+    }
+
+    // 删除不在设备列表中的项
+    for (NetworkDetails *detail : m_networkDetails) {
+        if (!devicePaths.contains(detail->devicePath())) {
+            m_networkDetails.removeOne(detail);
+            delete detail;
+        }
     }
 
     if (m_devices.size() > 0) {


### PR DESCRIPTION
网络详情同步算法有问题，导致与后端不同步。
v23合并导致 详情重复的问题复现

Log: 修复网络详情错误
Bug: https://pms.uniontech.com/bug-view-174677.html
Issue:  https://github.com/linuxdeepin/developer-center/issues/4312
Influence: 网络详情