### PR TITLE
fix: QuickPanel text is imcompleted when font set to 20

### DIFF
--- a/dock-hotspot-plugin/hotspotplugin.cpp
+++ b/dock-hotspot-plugin/hotspotplugin.cpp
@@ -206,13 +206,13 @@ const QString HotspotPlugin::itemCommand(const QString &itemKey) {
     reply.waitForFinished(); // force sync
     if(reply.isError())
       qWarning() << reply.error() << m_latestHotSpot->path();
-      return {};
+    return {};
   } else {
     if(!m_latestDevice.isNull() and !m_latestHotSpot.isNull()){
       auto reply = NetworkManager::activateConnection(m_latestHotSpot->path(),m_latestDevice->uni(),"/");
       reply.waitForFinished(); // force sync
       if(reply.isError())
-          qWarning() << "activate failed:" << reply.error();
+        qWarning() << "activate failed:" << reply.error();
       return {};
     }
   }

--- a/dock-hotspot-plugin/quickpanel.cpp
+++ b/dock-hotspot-plugin/quickpanel.cpp
@@ -69,7 +69,7 @@ void QuickPanel::initUi()
     m_icon->setCheckable(true);
 
     // text
-    m_text->setFixedHeight(15);
+    m_text->setFixedHeight(20);
     m_text->setAlignment(Qt::AlignCenter);
     m_text->setFont(Dtk::Widget::DFontSizeManager::instance()->t10());
     m_text->setText(tr("HotSpot"));


### PR DESCRIPTION
Log: 修复快捷面板上的文字在字号为20时不完整的问题