### PR TITLE
fix: NetworkPanel'status unrefreshed for dss-network-plugin

### DIFF
--- a/dss-network-plugin/network_module.h
+++ b/dss-network-plugin/network_module.h
@@ -93,7 +93,7 @@ public:
     void invokedMenuItem(const QString &menuId, const bool checked) const override;
 
 private:
-    void initUI();
+    void ensureNetwork();
 
 private:
     NetworkModule *m_network;


### PR DESCRIPTION
  NetworkDBusProxy is invalid, we delay construct NetworkModule to
avoid NetworkManager service hasn't ready, e.g: dde-session-daemon.