### PR TITLE
feat: Hide hotspot plugin when unsupport hotspot

### DIFF
--- a/dock-hotspot-plugin/CMakeLists.txt
+++ b/dock-hotspot-plugin/CMakeLists.txt
@@ -47,6 +47,7 @@ target_include_directories(${PLUGIN_NAME} PUBLIC
     ${KF5_QT_INCLUDE_DIRS}
     ${NETINTERFACEINCLUDE}
     "../common-plugin"
+    "../src"
 )
 
 target_link_libraries(${PLUGIN_NAME} PRIVATE
@@ -56,6 +57,7 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
     ${Qt5DBus_LIBRARIES}
     ${KF5_QT_LIBRARIES}
     ${Qt5Network_LIBRARIES}
+    ${DDE-Network-Core_LIBRARIES}
 )
 
 install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION lib/dde-dock/plugins/quick-trays)

--- a/dock-hotspot-plugin/hotspotplugin.h
+++ b/dock-hotspot-plugin/hotspotplugin.h
@@ -53,11 +53,12 @@ class HotspotPlugin : public QObject, PluginsItemInterface {
    void updateState(const NetworkManager::Device::Ptr& dev);
    void onQuickPanelClicked();
    void updateLatestHotSpot();
+    void onHotspotEnabledChanged();
+    void updateDockItemEnabled(bool isEnabled);
 
    bool hotspotEnabled{false};
    QScopedPointer<networkplugin::TipsWidget> m_tipsLabel{nullptr};
    NetworkManager::Device::List m_wirelessDev{};
-   NetworkManager::Notifier m_notifyer;
    QScopedPointer<QuickPanel> m_quickPanel{nullptr};
    NetworkManager::Connection::Ptr m_latestHotSpot{nullptr};
    NetworkManager::Device::Ptr m_latestDevice{nullptr};


### PR DESCRIPTION
  Monitoring device changed from m_notifier to NetworkManager::notifier.
  Removing item when foreach m_wirelessDevices, it causes app crashed.

Issue: https://github.com/linuxdeepin/developer-center/issues/5023