### PR TITLE
fix: Can't set connection when connecting

### DIFF
--- a/dcc-network-plugin/window/controllitemsmodel.cpp
+++ b/dcc-network-plugin/window/controllitemsmodel.cpp
@@ -28,8 +28,8 @@ struct ControllItemsAction
     DStandardItem *item;
 
     explicit ControllItemsAction(ControllItems *_conn)
-        : iconAction(new DViewItemAction(Qt::AlignCenter | Qt::AlignRight, QSize(), QSize(), true))
-        , spinnerAction(new DViewItemAction(Qt::AlignCenter | Qt::AlignRight, QSize(), QSize(), false))
+        : iconAction(new DViewItemAction(Qt::AlignLeft | Qt::AlignVCenter, QSize(), QSize(), true))
+        , spinnerAction(new DViewItemAction(Qt::AlignLeft | Qt::AlignVCenter, QSize(), QSize(), false))
         , loadingIndicator(nullptr)
         , conn(_conn)
         , item(new DStandardItem())
@@ -64,7 +64,6 @@ struct ControllItemsAction
             loadingIndicator->setVisible(false);
         }
         spinnerAction->setVisible(isLoading);
-        iconAction->setVisible(!isLoading);
     }
     Q_DISABLE_COPY(ControllItemsAction)
 };

--- a/dcc-network-plugin/window/wirelessdevicemodel.cpp
+++ b/dcc-network-plugin/window/wirelessdevicemodel.cpp
@@ -31,8 +31,8 @@ struct ItemAction
 
     explicit ItemAction(AccessPoints *_ap)
         : secureAction(new DViewItemAction(Qt::AlignCenter, QSize(), QSize(), false))
-        , iconAction(new DViewItemAction(Qt::AlignCenter | Qt::AlignRight, QSize(), QSize(), true))
-        , spinnerAction(new DViewItemAction(Qt::AlignCenter | Qt::AlignRight, QSize(), QSize(), false))
+        , iconAction(new DViewItemAction(Qt::AlignLeft | Qt::AlignVCenter, QSize(), QSize(), true))
+        , spinnerAction(new DViewItemAction(Qt::AlignLeft | Qt::AlignVCenter , QSize(), QSize(), false))
         , loadingIndicator(nullptr)
         , ap(_ap)
         , item(new DStandardItem())
@@ -67,7 +67,6 @@ struct ItemAction
             loadingIndicator->setVisible(false);
         }
         spinnerAction->setVisible(isLoading);
-        iconAction->setVisible(!isLoading);
     }
     Q_DISABLE_COPY(ItemAction)
 };


### PR DESCRIPTION
  Settings button is set invisible when connecting,
and DStyledItemDelegate can't support Qt::AlignRight for the action in DStyledItemDelegatePrivate::doActionsLayout
```
center_rect.setLeft(result_list.last().right() + spacing);
```
so we align it by AlignLeft.

Issue: https://github.com/linuxdeepin/developer-center/issues/5146