### PR TITLE
fix: OpenVPN网关校验等相关问题

### DIFF
--- a/dcc-network-plugin/window/sections/vpn/vpnopenvpnsection.cpp
+++ b/dcc-network-plugin/window/sections/vpn/vpnopenvpnsection.cpp
@@ -41,28 +41,31 @@ bool VpnOpenVPNSection::allInputValid()
 {
     bool valid = true;
 
-    if (m_gateway->text().isEmpty() || !isIpv4Address(m_gateway->text())) {
+    if (m_gateway->text().isEmpty()) {
         valid = false;
         m_gateway->setIsErr(true);
-        m_gateway->dTextEdit()->showAlertMessage(tr("Invalid gateway"), parentWidget(), 2000);
     } else {
         m_gateway->setIsErr(false);
     }
 
-    if (m_caFile->edit()->text().isEmpty())
+    if (m_caFile->edit()->text().isEmpty()) {
+        valid = false;
         m_caFile->setIsErr(true);
-    else
+    } else {
         m_caFile->setIsErr(false);
+    }
 
-    if (m_currentAuthType == "tls") {
-        valid = tlsItemsInputValid();
-    } else if (m_currentAuthType == "password") {
-        valid = passwordItemsInputValid();
+    if (m_currentAuthType == "tls" && !tlsItemsInputValid()) {
+        valid = false;
+    } else if (m_currentAuthType == "password" && !passwordItemsInputValid()) {
+        valid = false;
     } else if (m_currentAuthType == "password-tls") {
-        valid = tlsItemsInputValid();
-        valid = passwordItemsInputValid();
-    } else if (m_currentAuthType == "static-key") {
-        valid = staticKeyItemsInputValid();
+        if (!tlsItemsInputValid())
+            valid = false;
+        if (!passwordItemsInputValid())
+            valid = false;
+    } else if (m_currentAuthType == "static-key" && !staticKeyItemsInputValid()) {
+        valid = false;
     }
 
     return valid;


### PR DESCRIPTION
fix: OpenVPN网关校验等相关问题：
1、认证类型为“密码”时，当CA证书、用户名、密码均非空，而网关为空的情况下，点击保存按钮，网关校验结果会被覆盖为true 
2、未选择CA证书时，点击保存按钮，CA证书校验结果会被覆盖为true
3、网关栏校验仅允许纯ipv4地址通过，导致ipv6、域名、附带端口号、多个remote的情况下无法通过校验，影响使用。
