### PR TITLE
fix: interface-name is cleared after modifying the network profile

### DIFF
--- a/dcc-network-plugin/window/settings/abstractsettings.cpp
+++ b/dcc-network-plugin/window/settings/abstractsettings.cpp
@@ -64,11 +64,12 @@ bool AbstractSettings::isAutoConnect()
 
 void AbstractSettings::resetConnectionInterfaceName()
 {
-    if (!m_connSettings->interfaceName().isEmpty())
+    if (!m_connSettings->interfaceName().isEmpty()) {
         return;
+    }
 
-    if (ConnectionEditPage::devicePath().isEmpty() || clearInterfaceName()) {
-        m_connSettings->setInterfaceName(QString());
+    if (!setInterfaceName() || ConnectionEditPage::devicePath().isEmpty()) {
+        // 不设置 interfaceName
         return;
     }
 

--- a/dcc-network-plugin/window/settings/abstractsettings.h
+++ b/dcc-network-plugin/window/settings/abstractsettings.h
@@ -35,7 +35,7 @@ protected:
 
     // 是否清除连接的 interface-name 字段
     // 如果不设置连接的 macAddress 则需要清空 interface-name 字段, 反之不清空, 而是设置为当前设备的 interfaceName
-    virtual bool clearInterfaceName() = 0;
+    virtual bool setInterfaceName() { return true; }
 
 protected:
     virtual void resetConnectionInterfaceName();

--- a/dcc-network-plugin/window/settings/dslpppoesettings.cpp
+++ b/dcc-network-plugin/window/settings/dslpppoesettings.cpp
@@ -63,13 +63,3 @@ void DslPppoeSettings::initSections()
     m_settingSections.append(m_etherNetSection);
     m_settingSections.append(pppSection);
 }
-
-bool DslPppoeSettings::clearInterfaceName()
-{
-    ConnectionEditPage *page = dynamic_cast<ConnectionEditPage *>(m_parent);
-    if (page)
-        page->setDevicePath(m_etherNetSection->devicePath());
-
-    WiredSetting::Ptr wiredSetting = m_connSettings->setting(Setting::Wired).staticCast<WiredSetting>();
-    return wiredSetting->macAddress().isEmpty();
-}

--- a/dcc-network-plugin/window/settings/dslpppoesettings.h
+++ b/dcc-network-plugin/window/settings/dslpppoesettings.h
@@ -21,7 +21,6 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    bool clearInterfaceName() Q_DECL_OVERRIDE;
 
 private:
     QString m_devicePath;

--- a/dcc-network-plugin/window/settings/hotspotsettings.cpp
+++ b/dcc-network-plugin/window/settings/hotspotsettings.cpp
@@ -47,9 +47,3 @@ void HotspotSettings::initSections()
     m_settingSections.append(secretHotspotSection);
     m_settingSections.append(wirelessSection);
 }
-
-bool HotspotSettings::clearInterfaceName()
-{
-    WirelessSetting::Ptr wirelessSetting = m_connSettings->setting(Setting::SettingType::Wireless).staticCast<WirelessSetting>();
-    return wirelessSetting->macAddress().isEmpty();
-}

--- a/dcc-network-plugin/window/settings/hotspotsettings.h
+++ b/dcc-network-plugin/window/settings/hotspotsettings.h
@@ -19,7 +19,6 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    bool clearInterfaceName() Q_DECL_OVERRIDE;
 };
 
 #endif /* HOTSPOTSETTINGS_H */

--- a/dcc-network-plugin/window/settings/vpn/vpnl2tpsettings.h
+++ b/dcc-network-plugin/window/settings/vpn/vpnl2tpsettings.h
@@ -19,7 +19,7 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    inline bool clearInterfaceName() Q_DECL_OVERRIDE { return true; }
+    bool setInterfaceName() Q_DECL_OVERRIDE { return false; }
 };
 
 #endif

--- a/dcc-network-plugin/window/settings/vpn/vpnopenconnectsettings.h
+++ b/dcc-network-plugin/window/settings/vpn/vpnopenconnectsettings.h
@@ -19,7 +19,7 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    inline bool clearInterfaceName() Q_DECL_OVERRIDE { return true; }
+    bool setInterfaceName() Q_DECL_OVERRIDE { return false; }
 };
 
 #endif /* VPNOPENCONNECTSETTINGS_H */

--- a/dcc-network-plugin/window/settings/vpn/vpnopenvpnsettings.h
+++ b/dcc-network-plugin/window/settings/vpn/vpnopenvpnsettings.h
@@ -21,7 +21,7 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    bool clearInterfaceName() Q_DECL_OVERRIDE { return true; }
+    bool setInterfaceName() Q_DECL_OVERRIDE { return false; }
 };
 
 #endif /* VPNOPENVPNSETTINGS_H */

--- a/dcc-network-plugin/window/settings/vpn/vpnpptpsettings.h
+++ b/dcc-network-plugin/window/settings/vpn/vpnpptpsettings.h
@@ -19,7 +19,7 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    bool clearInterfaceName() Q_DECL_OVERRIDE { return true; }
+    bool setInterfaceName() Q_DECL_OVERRIDE { return false; }
 };
 
 #endif /* VPNPPTPSETTINGS_H */

--- a/dcc-network-plugin/window/settings/vpn/vpnsstpsettings.h
+++ b/dcc-network-plugin/window/settings/vpn/vpnsstpsettings.h
@@ -19,7 +19,7 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    bool clearInterfaceName() Q_DECL_OVERRIDE { return true; }
+    bool setInterfaceName() Q_DECL_OVERRIDE { return false; }
 };
 
 #endif /* VPNSSTPSETTINGS_H */

--- a/dcc-network-plugin/window/settings/vpn/vpnstrongswansettings.h
+++ b/dcc-network-plugin/window/settings/vpn/vpnstrongswansettings.h
@@ -19,7 +19,7 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    bool clearInterfaceName() Q_DECL_OVERRIDE { return true; }
+    bool setInterfaceName() Q_DECL_OVERRIDE { return false; }
 };
 
 #endif /* VPNSTRONGSWANSETTINGS_H */

--- a/dcc-network-plugin/window/settings/vpn/vpnvpncsettings.h
+++ b/dcc-network-plugin/window/settings/vpn/vpnvpncsettings.h
@@ -21,7 +21,7 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    bool clearInterfaceName() Q_DECL_OVERRIDE { return true; }
+    bool setInterfaceName() Q_DECL_OVERRIDE { return false; }
 };
 
 #endif /* VPNVPNCSETTINGS_H */

--- a/dcc-network-plugin/window/settings/wiredsettings.cpp
+++ b/dcc-network-plugin/window/settings/wiredsettings.cpp
@@ -9,6 +9,7 @@
 #include "sections/dnssection.h"
 #include "sections/ethernetsection.h"
 //#include "window/gsettingwatcher.h"
+#include "editpage/connectioneditpage.h"
 
 #include <widgets/lineeditwidget.h>
 #include <widgets/switchwidget.h>
@@ -85,28 +86,4 @@ void WiredSettings::initSections()
     m_settingSections.append(etherNetSection);
 
     m_ethernetSection = etherNetSection;
-}
-
-bool WiredSettings::clearInterfaceName()
-{
-    WiredSetting::Ptr wiredSetting = m_connSettings->setting(Setting::Wired).staticCast<WiredSetting>();
-    return wiredSetting->macAddress().isEmpty();
-}
-
-void WiredSettings::resetConnectionInterfaceName()
-{
-    if (!m_ethernetSection) {
-        AbstractSettings::resetConnectionInterfaceName();
-        return;
-    }
-
-    QString devicePath = m_ethernetSection->devicePath();
-    if (devicePath.isEmpty() || clearInterfaceName()) {
-        m_connSettings->setInterfaceName(QString());
-        return;
-    }
-
-    Device::Ptr dev = findNetworkInterface(devicePath);
-    if (dev)
-        m_connSettings->setInterfaceName(dev->interfaceName());
 }

--- a/dcc-network-plugin/window/settings/wiredsettings.h
+++ b/dcc-network-plugin/window/settings/wiredsettings.h
@@ -21,8 +21,6 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    bool clearInterfaceName() Q_DECL_OVERRIDE;
-    void resetConnectionInterfaceName() Q_DECL_OVERRIDE;
 
 private:
     EthernetSection *m_ethernetSection;

--- a/dcc-network-plugin/window/settings/wirelesssettings.cpp
+++ b/dcc-network-plugin/window/settings/wirelesssettings.cpp
@@ -90,9 +90,3 @@ void WirelessSettings::initSections()
     m_settingSections.append(dnsSection);
     m_settingSections.append(wirelessSection);
 }
-
-bool WirelessSettings::clearInterfaceName()
-{
-    WirelessSetting::Ptr wirelessSetting = m_connSettings->setting(Setting::SettingType::Wireless).staticCast<WirelessSetting>();
-    return wirelessSetting->macAddress().isEmpty();
-}

--- a/dcc-network-plugin/window/settings/wirelesssettings.h
+++ b/dcc-network-plugin/window/settings/wirelesssettings.h
@@ -20,7 +20,6 @@ public:
 
 protected:
     void initSections() Q_DECL_OVERRIDE;
-    bool clearInterfaceName() Q_DECL_OVERRIDE;
 
 private:
     ParametersContainer::Ptr m_parameter;


### PR DESCRIPTION
* 若本来有 interface-name，不处理
* 若 setInterfaceName() 返回 true，且 devPath 不为空，则设置 interface-name

Issues: linuxdeepin/developer-center#5804