### PR TITLE
fix: duplicate connection created in greeter 

### DIFF
--- a/dss-network-plugin/network_module.h
+++ b/dss-network-plugin/network_module.h
@@ -49,6 +49,7 @@ protected:
 
 private:
     void addFirstConnection(NetworkManager::WiredDevice *nmDevice);
+    bool hasConnection(NetworkManager::WiredDevice *nmDevice, NetworkManager::Connection::List &unSaveDevices);
     const QString connectionMatchName() const;
     void installTranslator(QString locale);
     bool needPopupNetworkDialog() const;


### PR DESCRIPTION
Available connections is always empty when device is not available.
Iterate connection list to find a matched connection instead.

Log: fix duplicate connection created in greeter
Issue: https://github.com/linuxdeepin/developer-center/issues/7465