### PR TITLE
fix: loadingIndicator isn't deleted

### DIFF
--- a/dcc-network-plugin/window/wirelessdevicemodel.cpp
+++ b/dcc-network-plugin/window/wirelessdevicemodel.cpp
@@ -60,6 +60,10 @@ struct ItemAction
                 loadingIndicator = new DSpinner(parentView);
                 loadingIndicator->setFixedSize(24, 24);
                 spinnerAction->setWidget(loadingIndicator);
+                QObject::connect(spinnerAction, &DViewItemAction::destroyed, loadingIndicator, [this] {
+                    loadingIndicator->deleteLater();
+                    loadingIndicator = nullptr;
+                });
             }
             loadingIndicator->start();
         } else if (loadingIndicator) {


### PR DESCRIPTION
loadingIndicator is deleted after spinner action is deleted

Issue: https://github.com/linuxdeepin/developer-center/issues/5747