### PR TITLE
fix: empty network panel when unavailable

### DIFF
--- a/common-plugin/networkpluginhelper.cpp
+++ b/common-plugin/networkpluginhelper.cpp
@@ -85,7 +85,11 @@ void NetworkPluginHelper::initConnection()
 
 void NetworkPluginHelper::updatePluginState()
 {
-    m_pluginState = DeviceStatusHandler::pluginState();
+    auto state = DeviceStatusHandler::pluginState();
+    if (m_pluginState == state)
+        return;
+    m_pluginState = state;
+    Q_EMIT pluginStateChanged(state);
 }
 
 PluginState NetworkPluginHelper::getPluginState()

--- a/common-plugin/networkpluginhelper.h
+++ b/common-plugin/networkpluginhelper.h
@@ -51,6 +51,7 @@ Q_SIGNALS:
     void addDevice(const QString &devicePath);
     void viewUpdate();
     void iconChanged();
+    void pluginStateChanged(PluginState state);
 
 public:
     explicit NetworkPluginHelper(NetworkDialog *networkDialog, QObject *parent = Q_NULLPTR);

--- a/dss-network-plugin/network_module.h
+++ b/dss-network-plugin/network_module.h
@@ -7,10 +7,12 @@
 
 #include "tray_module_interface.h"
 #include "../common-plugin/utils.h"
+#include "item/devicestatushandler.h"
 
 #include <NetworkManagerQt/Device>
 #include <NetworkManagerQt/WiredDevice>
 
+class QLabel;
 NETWORKPLUGIN_BEGIN_NAMESPACE
 class NetworkPluginHelper;
 class NetworkDialog;
@@ -25,12 +27,33 @@ class PopupAppletManager;
  * 用于处理插件差异
  * NetworkModule处理信号槽有问题，固增加该类
  */
+class NetworkPanelContainer : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit NetworkPanelContainer(NETWORKPLUGIN_NAMESPACE::NetworkDialog *dialog, QWidget *parent = nullptr);
+    ~NetworkPanelContainer() override;
+    void sendWarnMessage(const QString &msg);
+    void clearWarnMessage();
+    void setContentWidget(QWidget *content);
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+public Q_SLOTS:
+    void onPluginStateChanged(PluginState state);
+
+private:
+    QLabel *m_warnLabel;
+    NETWORKPLUGIN_NAMESPACE::NetworkDialog *m_dialog;
+    QWidget *m_savedParent;
+    QWidget *m_contentWidget;
+};
 class NetworkModule : public QObject
 {
     Q_OBJECT
 
 public:
     explicit NetworkModule(QObject *parent = nullptr);
+    ~NetworkModule() override;
 
     QWidget *content();
     QWidget *itemTipsWidget() const;
@@ -58,6 +81,7 @@ private:
     NETWORKPLUGIN_NAMESPACE::NetworkPluginHelper *m_networkHelper;
     NETWORKPLUGIN_NAMESPACE::NetworkDialog *m_networkDialog;
     NETWORKPLUGIN_NAMESPACE::SecretAgent *m_secretAgent;
+    QPointer<NetworkPanelContainer> m_panelContainer;
 
     bool m_isLockModel;  // 锁屏 or greeter
     bool m_isLockScreen; // 锁屏显示


### PR DESCRIPTION
When plugin state is Nocable, Disabled and Unknown(Usually means that NetworkManager is not running or there is no cable), the network panel list is empty in dde-session-shell and there is no warning message. Display a warning message.

Log: fix empty network panel when unavailable.
Issue: https://github.com/linuxdeepin/developer-center/issues/7208