### PR TITLE
fix: netItem textColor error and the selected button is not centered 

### DIFF
--- a/common-plugin/networkdialog/item/netitem.cpp
+++ b/common-plugin/networkdialog/item/netitem.cpp
@@ -46,7 +46,8 @@ NetItem::NetItem(QWidget *parent)
     m_standardItem->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
     m_standardItem->setData(NetConnectionType::UnConnected, ConnectionStatusRole);
     m_standardItem->setBackground(Qt::transparent);
-    m_standardItem->setTextColorRole(DPalette::BrightText);
+    QColor textColor(Qt::white);
+    m_standardItem->setData(textColor, Qt::ForegroundRole);
 }
 
 NetItem::~NetItem()

--- a/common-plugin/networkdialog/networkpanel.cpp
+++ b/common-plugin/networkdialog/networkpanel.cpp
@@ -1162,7 +1162,7 @@ bool NetworkDelegate::editorEvent(QEvent *event, QAbstractItemModel *model, cons
 QRect NetworkDelegate::checkRect(const QRect &rct) const
 {
     int left = rct.right() - RIGHTMARGIN - DIAMETER + 4;
-    int top = rct.top() + (DIAMETER / 2); // 连接图标绘制在顶端
+    int top = rct.top() + (rct.height() - DIAMETER) / 2; // 连接图标绘制在顶端
     QRect rect;
     rect.setLeft(left);
     rect.setTop(top);


### PR DESCRIPTION
Set the text color to white in lock

Issue: https://github.com/linuxdeepin/developer-center/issues/8505wq