### PR TITLE
fix: secure icons in lock screen are too small

### DIFF
--- a/common-plugin/networkdialog/item/netitem.cpp
+++ b/common-plugin/networkdialog/item/netitem.cpp
@@ -22,6 +22,7 @@
 #include <QPushButton>
 #include <QHBoxLayout>
 #include <QTimer>
+#include <DStyle>
 
 #include <networkdevicebase.h>
 #include <wireddevice.h>
@@ -368,10 +369,10 @@ void WirelessItem::initUi(QWidget *parent)
     standardItem()->setActionList(Qt::BottomEdge, { m_expandItem });
     m_expandItem->setVisible(false);
     // 左侧的加密图标
-    m_securityAction = new DViewItemAction(Qt::AlignLeft , QSize(20, 35), QSize(20, 35), false);
+    m_securityAction = new DViewItemAction(Qt::AlignCenter, QSize(), QSize(), false);
     updateSrcirityIcon();
     // 绘制WiFi图标
-    m_wifiLabel = new DViewItemAction(Qt::AlignLeft , QSize(20, 35), QSize(8, 35), false);
+    m_wifiLabel = new DViewItemAction(Qt::AlignLeft | Qt::AlignVCenter , QSize(), QSize(), false);
     updateWifiIcon();
 
     standardItem()->setSizeHint(QSize(-1, 36));
@@ -406,9 +407,9 @@ void WirelessItem::initConnection()
 void WirelessItem::updateSrcirityIcon()
 {
     if (m_accessPoint && m_accessPoint->secured()) {
-        QString srcirityIcon = ThemeManager::ref().getIcon("security");
+        DStyleHelper helper(qobject_cast<QWidget *>(parent())->style());
         // 更新加密图标
-        m_securityAction->setIcon(QIcon(srcirityIcon));
+        m_securityAction->setIcon(helper.standardIcon(DStyle::SP_LockElement, nullptr, nullptr));
     } else {
         m_securityAction->setIcon(QIcon());
     }


### PR DESCRIPTION
Issues: linuxdeepin/developer-center#8504