### PR TITLE
fix: VPN gateway cannot input ip:port

### DIFF
--- a/dcc-network-plugin/window/sections/vpn/vpnopenconnectsection.cpp
+++ b/dcc-network-plugin/window/sections/vpn/vpnopenconnectsection.cpp
@@ -39,7 +39,7 @@ bool VpnOpenConnectSection::allInputValid()
 {
     bool valid = true;
 
-    if (m_gateway->text().isEmpty() || !isIpv4Address(m_gateway->text())) {
+    if (m_gateway->text().isEmpty()) {
         valid = false;
         m_gateway->setIsErr(true);
         m_gateway->dTextEdit()->showAlertMessage(tr("Invalid gateway"), parentWidget(), 2000);

--- a/dcc-network-plugin/window/sections/vpn/vpnsection.cpp
+++ b/dcc-network-plugin/window/sections/vpn/vpnsection.cpp
@@ -44,7 +44,7 @@ bool VpnSection::allInputValid()
 {
     bool valid = true;
 
-    if (m_gateway->text().isEmpty() || !isIpv4Address(m_gateway->text())) {
+    if (m_gateway->text().isEmpty()) {
         valid = false;
         m_gateway->setIsErr(true);
         m_gateway->dTextEdit()->showAlertMessage(tr("Invalid gateway"), parentWidget(), 2000);

--- a/dcc-network-plugin/window/sections/vpn/vpnstrongswansection.cpp
+++ b/dcc-network-plugin/window/sections/vpn/vpnstrongswansection.cpp
@@ -51,7 +51,7 @@ bool VpnStrongSwanSection::allInputValid()
 {
     bool valid = true;
 
-    if (m_gateway->text().isEmpty() || !isIpv4Address(m_gateway->text())) {
+    if (m_gateway->text().isEmpty()) {
         valid = false;
         m_gateway->setIsErr(true);
         m_gateway->dTextEdit()->showAlertMessage(tr("Invalid gateway"), parentWidget(), 2000);

--- a/dcc-network-plugin/window/sections/vpn/vpnvpncsection.cpp
+++ b/dcc-network-plugin/window/sections/vpn/vpnvpncsection.cpp
@@ -50,7 +50,7 @@ bool VpnVPNCSection::allInputValid()
 {
     bool valid = true;
 
-    if (m_gateway->text().isEmpty() || !isIpv4Address(m_gateway->text())) {
+    if (m_gateway->text().isEmpty()) {
         valid = false;
         m_gateway->setIsErr(true);
         m_gateway->dTextEdit()->showAlertMessage(tr("Invalid gateway"), parentWidget(), 2000);


### PR DESCRIPTION
Remove verification of the gateway
If the user fills in the wrong gateway information, there will be a prompt indicating that they cannot connect

与产品沟通, 去掉对网关的校验, 与v20专业版和20.9保持一致, 若用户输入错误的网关, 会有连接失败的提示

Issue: https://github.com/linuxdeepin/developer-center/issues/9437