### PR TITLE
chore: bump version to 2.0.29

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-network-core (2.0.29) unstable; urgency=medium
+
+  * fix(dss): input  is not hidden after closing the window
+    (linuxdeepin/developer-center#8983)
+
+ -- zsien <quezhiyong@deepin.org>  Mon, 08 Jul 2024 10:23:22 +0800
+
 dde-network-core (2.0.28) unstable; urgency=medium
 
   * fix: icon drift on the left side of listView(Issue: https://github.com/linuxdeepin/developer-center/issues/8982)


### PR DESCRIPTION
  * fix(dss): input  is not hidden after closing the window (linuxdeepin/developer-center#8983)