### PR TITLE
fix: Modifying configuration errors can also set proxy issues

### DIFF
--- a/dcc-network-plugin/window/sysproxymodule.h
+++ b/dcc-network-plugin/window/sysproxymodule.h
@@ -41,6 +41,7 @@ private Q_SLOTS:
     void applySettings();
     void uiMethodChanged(dde::network::ProxyMethod uiMethod);
     void resetData(dde::network::ProxyMethod uiMethod);
+    void checkConf();
 
 private:
     virtual bool eventFilter(QObject *watched, QEvent *event) override;

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-network-core (2.0.31) unstable; urgency=medium
+
+  * fix: Modify the interface to display multiple system proxy issues(Issue: 9961)
+  * fix: Modifying configuration errors can also set proxy issues(Issue: 9983)
+
+ -- caixiangrong <caixiangrong@uniontech.com>  Fri, 26 Jul 2024 16:25:40 +0800
+
 dde-network-core (2.0.30) unstable; urgency=medium
 
   * fix: Responding to proxy change signals (#252)(Issue: 9711)


### PR DESCRIPTION
When configuring incorrectly, setting the proxy did not take effect, resulting in asynchronous network proxy status on the taskbar

Issue: https://github.com/linuxdeepin/developer-center/issues/9983