### PR TITLE
fix: Modify network plugin translation issues

### DIFF
--- a/dss-network-plugin/network_module.h
+++ b/dss-network-plugin/network_module.h
@@ -68,8 +68,6 @@ public:
 
 protected Q_SLOTS:
     void updateLockScreenStatus(bool visible);
-
-protected:
     void onDeviceStatusChanged(NetworkManager::Device::State newstate, NetworkManager::Device::State oldstate, NetworkManager::Device::StateChangeReason reason);
     void onAddDevice(const QString &path);
     void onUserChanged(QString json);


### PR DESCRIPTION
The onUserChanged function requires the Q_SLOTS identifier

Issue: https://github.com/linuxdeepin/developer-center/issues/10071