### PR TITLE
fix: Modify network plugin crash issue

### DIFF
--- a/src/realize/devicemanagerrealize.cpp
+++ b/src/realize/devicemanagerrealize.cpp
@@ -299,7 +299,6 @@ void DeviceManagerRealize::onWiredConnectionChanged()
     QList<WiredConnection *> rmConnection;
     for (WiredConnection *conn : m_wiredConnections) {
         if (!allConnection.contains(conn)) {
-            m_wiredConnections.removeOne(conn);
             rmConnection << conn;
         }
     }
@@ -525,7 +524,6 @@ void DeviceManagerRealize::createWlans(QList<WirelessConnection *> &allConnectio
     QList<AccessPoints *> rmAps;
     for (AccessPoints *ap : m_accessPoints) {
         if (!allAccessPoints.contains(ap)) {
-            m_accessPoints.removeOne(ap);
             rmAps << ap;
         }
     }


### PR DESCRIPTION
Deleting loop objects within the loop leads to a crash

Issue: https://github.com/linuxdeepin/developer-center/issues/10263