### PR TITLE
fix: Modifying VPN configuration file without naming issue

### DIFF
--- a/dcc-network/qml/PageVPNSettings.qml
+++ b/dcc-network/qml/PageVPNSettings.qml
@@ -221,6 +221,7 @@ DccObject {
                     visible: false
                     fileMode: FileDialog.SaveFile
                     nameFilters: [qsTr("*.conf")]
+                    currentFile: root.config.connection.id
                     onAccepted: {
                         dccData.exec(NetManager.ExportConnect, item.id, {
                                          "file": currentFile.toString().replace("file://", "")


### PR DESCRIPTION
Modifying VPN configuration file without naming issue

pms: BUG-287091