### PR TITLE
fix: Password configuration should not be saved without a password

### DIFF
--- a/net-view/operation/private/netmanagerthreadprivate.cpp
+++ b/net-view/operation/private/netmanagerthreadprivate.cpp
@@ -922,7 +922,7 @@ void NetManagerThreadPrivate::doConnectOrInfo(const QString &id, NetType::NetIte
                     wsSetting->setKeyMgmt(keyMgmt);
                     break;
                 }
-                wsSetting->setInitialized(true);
+                wsSetting->setInitialized(keyMgmt != WirelessSecuritySetting::KeyMgmt::WpaNone);
                 QString uuid = settings->createNewUuid();
                 while (findConnectionByUuid(uuid)) {
                     qint64 second = QDateTime::currentDateTime().toSecsSinceEpoch();


### PR DESCRIPTION
Password configuration should not be saved without a password

pms: BUG-298371