### PR TITLE
fix: Modifying network connection issue without automatic creation

### DIFF
--- a/network-service-plugin/accountnetwork/session/accountnetwork/activeaccoutnetwork.h
+++ b/network-service-plugin/accountnetwork/session/accountnetwork/activeaccoutnetwork.h
@@ -48,6 +48,8 @@ private:
 private slots:
     void onAuthen(const QVariantMap &identity);
     void onCollectionCreated(const QDBusObjectPath &path);
+    void onActiveConnectionChanged();
+    void onStateChanged(NetworkManager::ActiveConnection::State state);
 
 private:
     Account *m_account;

--- a/network-service-plugin/system/networkinitialization.h
+++ b/network-service-plugin/system/networkinitialization.h
@@ -45,6 +45,8 @@ private slots:
     void onUserChanged(const QString &json);
     void onUserAdded(const QString &json);
     void onInitDeviceConnection();
+    void onAddFirstConnection();
+    void onManagedChanged();
 
 private:
     QStringList m_newConnectionNames;


### PR DESCRIPTION
QObject::connect: Unique connection requires the slot to be a pointer to a member function of a QObject subclass.

pms: BUG-307619