### PR TITLE
fix: Synchronize dss-network-plugin 107x interface

### DIFF
--- a/dss-network-plugin/networkmodule.h
+++ b/dss-network-plugin/networkmodule.h
@@ -32,6 +32,7 @@ public:
     virtual QWidget *itemTipsWidget() const;
     virtual const QString itemContextMenu() const;
     virtual void invokedMenuItem(const QString &menuId, const bool checked) const;
+    void installTranslator(const QString &locale);
 
     inline dde::network::NetStatus *netStatus() const { return m_netStatus; }
 
@@ -43,9 +44,6 @@ protected Q_SLOTS:
     virtual void updateLockScreenStatus(bool visible);
     void onUserChanged(const QString &json);
     void onNotify(uint replacesId);
-
-private:
-    void installTranslator(const QString &locale);
 
 protected:
     QWidget *m_contentWidget;
@@ -93,6 +91,7 @@ public:
 
     void requestShowContent();
     void setMessage(bool visible);
+    QString message(const QString &msgData) override;
 
 Q_SIGNALS:
     void notifyNetworkStateChanged(bool);

--- a/net-view/operation/netmanager.cpp
+++ b/net-view/operation/netmanager.cpp
@@ -835,9 +835,13 @@ void NetManagerPrivate::clearPasswordRequest(const QString &id)
 
 void NetManagerPrivate::retranslateUi()
 {
-    // for (auto &&item : m_dataMap) {
-    //     item->retranslateUi();
-    // }
+    QVector<NetItem *> items;
+    items.append(m_root->item());
+    while (!items.isEmpty()) {
+        NetItem *item = items.takeFirst();
+        Q_EMIT item->nameChanged(item->name());
+        items.append(item->getChildren());
+    }
 }
 
 void NetManagerPrivate::onItemDestroyed(QObject *obj)

--- a/net-view/operation/private/netmanagerthreadprivate.cpp
+++ b/net-view/operation/private/netmanagerthreadprivate.cpp
@@ -299,7 +299,7 @@ void NetManagerThreadPrivate::userCancelRequest(const QString &id)
 
 void NetManagerThreadPrivate::retranslate(const QString &locale)
 {
-    NetworkController::installTranslator(QLocale().name());
+    NetworkController::installTranslator(locale);
     if (m_isInitialized)
         QMetaObject::invokeMethod(this, "doRetranslate", Qt::QueuedConnection, Q_ARG(QString, locale));
 }


### PR DESCRIPTION
Synchronize dss-network-plugin 107x interface

pms: TASK-361719

## Summary by Sourcery

Enhance network plugin localization by adding support for dynamic language updates across network services

New Features:
- Add a new method to dynamically update language settings for network services via D-Bus

Bug Fixes:
- Ensure proper handling of language update requests with robust error checking

Enhancements:
- Implement a mechanism to synchronize language settings between network plugin and system network service
- Add service watcher to handle language updates when network service is not immediately available