### PR TITLE
fix: DSL should not be displayed without wired network devices

### DIFF
--- a/dcc-network/qml/PageDSL.qml
+++ b/dcc-network/qml/PageDSL.qml
@@ -18,7 +18,7 @@ DccObject {
     displayName: qsTr("DSL")
     description: qsTr("Set up a dial-up network connection")
     icon: "dcc_dsl"
-    visible: item
+    visible: item.enabledable
     page: DccSettingsView {}
 
     DccObject {

--- a/net-view/operation/private/netmanagerthreadprivate.h
+++ b/net-view/operation/private/netmanagerthreadprivate.h
@@ -178,6 +178,7 @@ protected Q_SLOTS:
     void onDeviceAdded(QList<NetworkDeviceBase *> devices);
     void onDeviceRemoved(QList<NetworkDeviceBase *> devices);
     void onConnectivityChanged();
+    void updateDSLEnabledable();
     // Wired
     void onConnectionAdded(const QList<WiredConnection *> &conns);
     void onConnectionRemoved(const QList<WiredConnection *> &conns);


### PR DESCRIPTION
DSL should not be displayed without wired network devices

pms: BUG-311983

## Summary by Sourcery

Modify DSL network item visibility to only show when wired network devices are present

Bug Fixes:
- Prevent DSL network item from being displayed when no wired network devices are available

Enhancements:
- Add a new method to dynamically control DSL item visibility based on network device presence