### PR TITLE
fix: Modifying the opening and closing of VPN caused a crash issue

### DIFF
--- a/net-view/operation/private/netitemprivate.cpp
+++ b/net-view/operation/private/netitemprivate.cpp
@@ -30,6 +30,7 @@ namespace network {
  */
 NetItemPrivate::NetItemPrivate()
     : m_item(nullptr)
+    , m_parent(nullptr)
 {
 }
 

--- a/net-view/window/netview.cpp
+++ b/net-view/window/netview.cpp
@@ -83,9 +83,9 @@ NetView::NetView(NetManager *manager)
     connect(this, &NetView::activated, this, &NetView::onActivated);
 
     // 支持在触摸屏上滚动
-    //QScroller::grabGesture(viewport(), QScroller::LeftMouseButtonGesture);
-    //QScrollerProperties sp;
-    //sp.setScrollMetric(QScrollerProperties::VerticalOvershootPolicy, QScrollerProperties::OvershootAlwaysOff);
+    // QScroller::grabGesture(viewport(), QScroller::LeftMouseButtonGesture);
+    // QScrollerProperties sp;
+    // sp.setScrollMetric(QScrollerProperties::VerticalOvershootPolicy, QScrollerProperties::OvershootAlwaysOff);
 }
 
 NetView::~NetView() = default;
@@ -143,7 +143,7 @@ void NetView::rowsInserted(const QModelIndex &parent, int start, int end)
         NetWirelessOtherItem *otherItem = NetItem::toItem<NetWirelessOtherItem>(item);
         if (otherItem) {
             updateItemExpand(otherItem);
-            connect(otherItem, &NetWirelessOtherItem::expandedChanged, this, &NetView::onExpandStatusChanged);
+            connect(otherItem, &NetWirelessOtherItem::expandedChanged, this, &NetView::onExpandStatusChanged, Qt::UniqueConnection);
         }
     } break;
     case NetType::WirelessMineItem:
@@ -152,8 +152,8 @@ void NetView::rowsInserted(const QModelIndex &parent, int start, int end)
     case NetType::VPNControlItem: {
         NetVPNControlItem *vpnControlItem = NetItem::toItem<NetVPNControlItem>(item);
         if (vpnControlItem) {
-            connect(vpnControlItem, &NetVPNControlItem::expandedChanged, this, &NetView::onExpandStatusChanged);
-            connect(vpnControlItem, &NetVPNControlItem::enabledChanged, this, &NetView::onExpandStatusChanged);
+            connect(vpnControlItem, &NetVPNControlItem::expandedChanged, this, &NetView::onExpandStatusChanged, Qt::UniqueConnection);
+            connect(vpnControlItem, &NetVPNControlItem::enabledChanged, this, &NetView::onExpandStatusChanged, Qt::UniqueConnection);
             updateItemExpand(vpnControlItem);
         }
     } break;
@@ -164,9 +164,9 @@ void NetView::rowsInserted(const QModelIndex &parent, int start, int end)
         NetDeviceItem *dev = NetItem::toItem<NetDeviceItem>(item);
         if (dev) {
             updateItemExpand(dev);
-            connect(dev, &NetDeviceItem::enabledChanged, this, &NetView::onExpandStatusChanged);
+            connect(dev, &NetDeviceItem::enabledChanged, this, &NetView::onExpandStatusChanged, Qt::UniqueConnection);
             if (dev->itemType() == NetType::WirelessDeviceItem)
-                connect(NetItem::toItem<NetWirelessDeviceItem>(dev), &NetWirelessDeviceItem::apModeChanged, this, &NetView::onExpandStatusChanged);
+                connect(NetItem::toItem<NetWirelessDeviceItem>(dev), &NetWirelessDeviceItem::apModeChanged, this, &NetView::onExpandStatusChanged, Qt::UniqueConnection);
         }
     } break;
     default:
@@ -281,6 +281,9 @@ void NetView::updateItemExpand(NetItem *item)
         return;
     }
     QModelIndex sIndex = m_model->index(item);
+    if (!sIndex.isValid()) {
+        return;
+    }
     QModelIndex index = m_proxyModel->mapFromSource(sIndex);
     if (isExpanded(index) != expandItem) {
         setExpanded(index, expandItem);

--- a/net-view/window/private/netmodel.cpp
+++ b/net-view/window/private/netmodel.cpp
@@ -87,6 +87,13 @@ QModelIndex NetModel::index(const NetItem *object)
     if (!parent) {
         return QModelIndex();
     }
+    NetItem *ancestor = parent;
+    while (ancestor && ancestor != m_treeRoot) {
+        ancestor = ancestor->getParent();
+    }
+    if (ancestor != m_treeRoot) {
+        return QModelIndex();
+    }
 
     int pos = parent->getChildIndex(object);
     assert(pos >= 0);


### PR DESCRIPTION
Unfolding item error caused when VPN does not exist

pms: BUG-313961

## Summary by Sourcery

Fix potential crash and improve stability in network view item handling by adding null checks and preventing duplicate signal connections

Bug Fixes:
- Prevent potential crash when accessing network items with invalid model indexes
- Ensure safe handling of VPN and network item expansions by adding additional null checks

Enhancements:
- Improve signal connection robustness by using Qt::UniqueConnection to prevent multiple connections
- Add parent validation in model index retrieval to prevent potential null pointer access