### PR TITLE
fix: Modify icon color processing

### DIFF
--- a/dock-network-plugin/quickpanelwidget.cpp
+++ b/dock-network-plugin/quickpanelwidget.cpp
@@ -56,7 +56,6 @@ protected:
         }
         option->palette.setBrush(QPalette::Button, bgColor);
         option->palette.setBrush(QPalette::ButtonText, textColor);
-        option->palette.setBrush(QPalette::WindowText, Qt::red);
         option->state.setFlag(QStyle::State_MouseOver, false);
         option->state.setFlag(QStyle::State_Sunken, false);
         option->state.setFlag(QStyle::State_Raised, true);
@@ -79,19 +78,12 @@ QuickPanelWidget::~QuickPanelWidget() { }
 void QuickPanelWidget::setIcon(const QIcon &icon)
 {
 
-    // DDciIcon dciIcon = DDciIcon::fromTheme(icon.name());
-    // if(dciIcon.isNull()){
+    DDciIcon dciIcon = DDciIcon::fromTheme(icon.name());
+    if (dciIcon.isNull()) {
         m_iconWidget->setIcon(icon);
-    // }else{
-    //     m_iconWidget->setIcon(dciIcon);
-    // }
-    // m_iconWidget->setIcon(icon);
-    // // "network-wireless-6-offline-secure-symbolic"
-    // DDciIcon::fromTheme("network-wireless-6-offline-secure-symbolic");
-    // m_iconWidget->setIcon(DDciIcon::fromTheme("network-wireless-6-offline-secure-symbolic"));
-    // DDciIcon::fromTheme("network-wireless-6-offline-secure-symbolic");
-    // m_iconWidget->setIcon(QIcon::fromTheme("network-wireless-6-offline-secure-symbolic"));
-    // network-wireless-6-signal-full-secure-symbolic_16px.svg
+    } else {
+        m_iconWidget->setIcon(dciIcon);
+    }
 }
 
 void QuickPanelWidget::setText(const QString &text)

--- a/net-view/window/private/neticonbutton.cpp
+++ b/net-view/window/private/neticonbutton.cpp
@@ -17,6 +17,7 @@ NetIconButton::NetIconButton(QWidget *parent)
     , m_clickable(false)
     , m_rotatable(false)
     , m_hover(false)
+    , m_textType(true)
 {
     setAccessibleName("NetIconButton");
     setFixedSize(24, 24);
@@ -48,6 +49,12 @@ void NetIconButton::setRotatable(bool rotatable)
             delete m_refreshTimer;
         m_refreshTimer = nullptr;
     }
+}
+
+void NetIconButton::setTextType(bool textType)
+{
+    m_textType = textType;
+    update();
 }
 
 void NetIconButton::startRotate()
@@ -93,18 +100,27 @@ void NetIconButton::paintEvent(QPaintEvent *e)
         return;
     QPainter painter(this);
     painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
-
+    QRect r = rect();
     if (m_rotateAngle != 0) {
-        painter.translate(this->width() / 2, this->height() / 2);
+        painter.translate(r.width() / 2, r.height() / 2);
         painter.rotate(m_rotateAngle);
-        painter.translate(-(this->width() / 2), -(this->height() / 2));
+        painter.translate(-(r.width() / 2), -(r.height() / 2));
     }
-
+    const qreal scale = devicePixelRatio();
+    QSize pixmapSize = r.size() * scale;
+    QPixmap pm;
     if (m_hover && !m_hoverIcon.isNull()) {
-        m_hoverIcon.paint(&painter, rect());
+        pm = m_hoverIcon.pixmap(pixmapSize);
     } else {
-        m_icon.paint(&painter, rect());
+        pm = m_icon.pixmap(pixmapSize);
     }
+    if (m_textType) {
+        QPainter pa(&pm);
+        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
+        pa.fillRect(r, painter.pen().brush());
+    }
+    pm.setDevicePixelRatio(scale);
+    painter.drawPixmap(r, pm);
 }
 
 void NetIconButton::mousePressEvent(QMouseEvent *event)

--- a/net-view/window/private/neticonbutton.h
+++ b/net-view/window/private/neticonbutton.h
@@ -22,6 +22,7 @@ public Q_SLOTS:
 
     void setClickable(bool clickable);
     void setRotatable(bool rotatable);
+    void setTextType(bool textType);
 
 signals:
     void clicked();
@@ -44,6 +45,7 @@ private:
     bool m_clickable;
     bool m_rotatable;
     bool m_hover;
+    bool m_textType;
 };
 
 } // namespace network


### PR DESCRIPTION
Modify icon color processing

pms: TASK-361719

## Summary by Sourcery

Modify icon color handling in `NetIconButton` to allow tinting based on text color and update icon loading in `QuickPanelWidget`.

Enhancements:
- Add a `textType` property to `NetIconButton` to enable icon tinting using the current text color.
- Load theme-aware icons (`DDciIcon`) in `QuickPanelWidget` when available.
- Remove unused code and a debug color setting related to icon handling in `QuickPanelWidget`.