### PR TITLE
fix: Modifying network configuration displays errors

### DIFF
--- a/dcc-network/qml/SectionSecret.qml
+++ b/dcc-network/qml/SectionSecret.qml
@@ -78,9 +78,9 @@ DccTitleObject {
         switch (root.keyMgmt) {
         case "wpa-eap":
             root.config802_1x = c ? c : {}
+            root.eapType = "peap"
             if (root.config802_1x && root.config802_1x.hasOwnProperty("eap") && root.config802_1x.eap.length > 0) {
                 root.eapType = root.config802_1x["eap"][0]
-                console.log("sss===root.eapType=", root.eapType)
             }
             switch (root.eapType) {
             case "tls":

--- a/net-view/operation/nettype.h
+++ b/net-view/operation/nettype.h
@@ -76,19 +76,20 @@ public:
     Q_ENUM(NetDeviceStatus)
 
     enum NetManagerFlag {
-        Net_ServiceNM = 0x00000001,         // 使用NM
-        Net_MonitorNotify = 0x00000002,     // 发网络通知
-        Net_AutoAddConnection = 0x00000004, // 自动添加连接
-        Net_UseSecretAgent = 0x00000008,    // 实现密码代理
-        Net_CheckPortal = 0x00000010,       // 设置检查认证网页
-        Net_tipsLinkEnabled = 0x00000020,   // 可跳转连接
+        Net_ServiceNM = 0x00000001,              // 使用NM
+        Net_MonitorNotify = 0x00000002,          // 发网络通知
+        Net_AutoAddConnection = 0x00000004,      // 自动添加连接
+        Net_UseSecretAgent = 0x00000008,         // 实现密码代理
+        Net_CheckPortal = 0x00000010,            // 设置检查认证网页
+        Net_tipsLinkEnabled = 0x00000020,        // 可跳转连接
+        Net_autoUpdateHiddenConfig = 0x00000040, // 自动更新隐藏网络配置
 
-        Net_8021xToConnect = 0x00000100,                                               // 连接
-        Net_8021xToControlCenter = 0x00000200,                                         // 跳转控制中心
-        Net_8021xSendNotify = 0x00000400,                                              // 发通知
-        Net_8021xUnderConnect = 0x00000800,                                            // 优先读配置
-        Net_8021xToControlCenterUnderConnect = Net_8021xUnderConnect | Net_8021xToControlCenter,   // 如果设置了此项，则先于配置读取是否直接连接，如果配置中没有，就设置为跳转到控制中心
-        Net_8021xSendNotifyUnderConnect = Net_8021xUnderConnect | Net_8021xSendNotify, // 如果设置了此项，则先于配置中读取是否直接连接，如果配置中没有，就设置为直接发送消息
+        Net_8021xToConnect = 0x00000100,                                                         // 连接
+        Net_8021xToControlCenter = 0x00000200,                                                   // 跳转控制中心
+        Net_8021xSendNotify = 0x00000400,                                                        // 发通知
+        Net_8021xUnderConnect = 0x00000800,                                                      // 优先读配置
+        Net_8021xToControlCenterUnderConnect = Net_8021xUnderConnect | Net_8021xToControlCenter, // 如果设置了此项，则先于配置读取是否直接连接，如果配置中没有，就设置为跳转到控制中心
+        Net_8021xSendNotifyUnderConnect = Net_8021xUnderConnect | Net_8021xSendNotify,           // 如果设置了此项，则先于配置中读取是否直接连接，如果配置中没有，就设置为直接发送消息
 
         Net_Device = 0x00010000,
         Net_VPN = 0x00020000,
@@ -104,7 +105,7 @@ public:
         Net_VPNChildren = 0x04000000,
 
         //
-        Net_DockFlags = Net_Device | Net_VPN | Net_SysProxy | Net_Airplane | Net_AirplaneTips | Net_VPNTips | Net_tipsLinkEnabled | Net_UseSecretAgent | Net_CheckPortal | Net_8021xToControlCenterUnderConnect,
+        Net_DockFlags = Net_Device | Net_VPN | Net_SysProxy | Net_Airplane | Net_AirplaneTips | Net_VPNTips | Net_tipsLinkEnabled | Net_UseSecretAgent | Net_CheckPortal | Net_8021xToControlCenterUnderConnect | Net_autoUpdateHiddenConfig,
         Net_LockFlags = Net_Device | Net_VPN | Net_SysProxy | Net_Airplane | Net_AirplaneTips | Net_VPNTips | Net_UseSecretAgent | Net_CheckPortal | Net_8021xSendNotify,
         Net_GreeterFlags = Net_Device | Net_Airplane | Net_AirplaneTips | Net_ServiceNM | Net_MonitorNotify | Net_AutoAddConnection | Net_UseSecretAgent | Net_CheckPortal | Net_8021xSendNotify,
         Net_DccFlags = Net_Device | Net_VPN | Net_VPNChildren | Net_SysProxy | Net_AppProxy | Net_Hotspot | Net_Airplane | Net_DSL | Net_Details,

--- a/net-view/operation/private/netmanagerthreadprivate.h
+++ b/net-view/operation/private/netmanagerthreadprivate.h
@@ -57,7 +57,6 @@ public:
     void setUseSecretAgent(bool enabled);
 
     void setEnabled(bool enabled);
-    void setAutoUpdateHiddenConfig(bool autoUpdate);
     void setAutoScanInterval(int ms);
     void setAutoScanEnabled(bool enabled);
     void setServerKey(const QString &serverKey);
@@ -244,7 +243,7 @@ protected Q_SLOTS:
     void updateHiddenNetworkConfig(WirelessDevice *wireless);
     bool needSetPassword(AccessPoints *accessPoint) const;
     void handleAccessPointSecure(AccessPoints *accessPoint);
-    bool handle8021xAccessPoint(AccessPoints *ap);
+    bool handle8021xAccessPoint(AccessPoints *ap, bool hidden);
     void onPrepareForSleep(bool state);
 
 protected:
@@ -272,7 +271,6 @@ private:
     // bool m_loadForNM;
     bool m_monitorNetworkNotify;
     bool m_useSecretAgent;
-    bool m_autoUpdateHiddenConfig; // 自动更新隐藏网络配置
     bool m_isInitialized;
     bool m_enabled;
     int m_autoScanInterval;

--- a/net-view/operation/private/netwirelessconnect.cpp
+++ b/net-view/operation/private/netwirelessconnect.cpp
@@ -5,6 +5,7 @@
 #include "netwirelessconnect.h"
 
 #include "configsetting.h"
+#include "nmnetworkmanager.h"
 
 #include <NetworkManagerQt/AccessPoint>
 #include <NetworkManagerQt/ActiveConnection>
@@ -440,8 +441,9 @@ void NetWirelessConnect::activateConnection()
         m_device->connectNetwork(id);
     } else {
         QVariantMap options;
+        options.insert("persist", "memory");
         options.insert("flags", MANUAL);
-        // NetworkManager::activateConnection2(conn->path(), m_device->path(), accessPointPath, options);
+        NetworkManager::activateConnection2(conn->path(), m_device->path(), accessPointPath, options);
     }
 }
 


### PR DESCRIPTION
When connecting to a hidden network, update the configuration according to the network encryption status

pms: BUG-313003

## Summary by Sourcery

Fix connection issues with hidden wireless networks, particularly WPA/WPA2 Enterprise, by correctly updating configuration based on actual network parameters.

Bug Fixes:
- Ensure correct security settings are used for hidden networks by fetching them directly from the access point.
- Prevent connection failures by removing stale temporary connection profiles for hidden networks.

Enhancements:
- Propagate the 'hidden' status when requesting connection details or user input via the control center.
- Activate connections for hidden networks temporarily in memory.
- Replace the boolean flag for updating hidden configurations with a bitmask flag.