### PR TITLE
fix: Add flags of wifi6

### DIFF
--- a/dcc-network/qml/PageWirelessDevice.qml
+++ b/dcc-network/qml/PageWirelessDevice.qml
@@ -69,7 +69,7 @@ DccObject {
                             rightPadding: 10
                             spacing: 10
                             icon {
-                                name: "network-wireless" + (item.flags & 0x10 ? "-6" : "") + c_levelString[item.strengthLevel] + (item.secure ? "-secure" : "") + "-symbolic"
+                                name: "network-wireless" + (item.flags ? "-6" : "") + c_levelString[item.strengthLevel] + (item.secure ? "-secure" : "") + "-symbolic"
                                 height: 16
                                 width: 16
                             }


### PR DESCRIPTION
Add flags of wifi6

pms: BUG-312633

## Summary by Sourcery

Bug Fixes:
- Updated WiFi icon flag condition to correctly display WiFi 6 network icons