### PR TITLE
chore: bump version to 2.0.56

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-network-core (2.0.56) unstable; urgency=medium
+
+  * fix: Add VPN configuration parameter check
+  * fix: Add flags of wifi6
+  * fix: Modify can't connect to new WiFi issues
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 08 May 2025 16:43:39 +0800
+
 dde-network-core (2.0.55) unstable; urgency=medium
 
   * fix: Modify icon color processing


### PR DESCRIPTION
update changelog to 2.0.56

## Summary by Sourcery

Chores:
- Update project version to 2.0.56