### PR TITLE
fix: Abnormal issue with modifying network icons

### DIFF
--- a/net-view/window/private/neticonbutton.cpp
+++ b/net-view/window/private/neticonbutton.cpp
@@ -117,7 +117,7 @@ void NetIconButton::paintEvent(QPaintEvent *e)
     if (m_textType) {
         QPainter pa(&pm);
         pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
-        pa.fillRect(r, painter.pen().brush());
+        pa.fillRect(pm.rect(), painter.pen().brush());
     }
     pm.setDevicePixelRatio(scale);
     painter.drawPixmap(r, pm);


### PR DESCRIPTION
Abnormal issue with modifying network icons

pms: BUG-315507

## Summary by Sourcery

Bug Fixes:
- Corrected the rectangle used when filling the pixmap to resolve icon rendering problems