### PR TITLE
fix: Block application proxy menu

### DIFF
--- a/dcc-network/qml/networkMain.qml
+++ b/dcc-network/qml/networkMain.qml
@@ -63,9 +63,9 @@ DccObject {
                 }
                 break
             case NetType.AppProxyControlItem:
-                if (appProxyPage.item !== item) {
-                    appProxyPage.item = item
-                }
+                // if (appProxyPage.item !== item) {
+                //     appProxyPage.item = item
+                // }
                 break
             case NetType.HotspotControlItem:
                 hotspotPage.setItem(item)


### PR DESCRIPTION
Block application proxy menu

pms: BUG-315249

## Summary by Sourcery

Bug Fixes:
- Prevent application proxy menu from being set or loaded