### PR TITLE
chore: bump version to 2.0.57

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-network-core (2.0.57) unstable; urgency=medium
+
+  * fix: add transifex config
+  * fix: Block application proxy menu
+  * fix: Abnormal issue with modifying network icons
+
+ -- caixiangrong <caixiangrong@uniontech.com>  Tue, 13 May 2025 16:50:40 +0800
+
 dde-network-core (2.0.56) unstable; urgency=medium
 
   * fix: Add VPN configuration parameter check


### PR DESCRIPTION
update changelog to 2.0.57