### PR TITLE
fix: when hide plugin,setting button sholud be hided

### DIFF
--- a/dock-network-plugin/widget/jumpsettingbutton.cpp
+++ b/dock-network-plugin/widget/jumpsettingbutton.cpp
@@ -79,6 +79,10 @@ bool JumpSettingButton::event(QEvent* e)
         m_hover = e->type() == QEvent::Enter;
         update();
         break;
+    case QEvent::Hide:
+        m_hover = false;
+        update();
+        break;
     default:
         break;
     }


### PR DESCRIPTION
as title

Log:

## Summary by Sourcery

Bug Fixes:
- Reset hover state and trigger update on QEvent::Hide so the setting button is properly hidden