### PR TITLE
fix: source string for dcc-network resource is empty

### DIFF
--- a/dcc-network/translations/network_en.ts
+++ b/dcc-network/translations/network_en.ts
@@ -1,3 +1,1725 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1"/>
+<TS version="2.1">
+<context>
+    <name>NetFileChooseEdit</name>
+    <message>
+        <source>All files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetPasswordEdit</name>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageAirplane</name>
+    <message>
+        <source>Airplane mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop wireless communication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enabling the airplane mode turns off wireless network, personal hotspot and Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageAppProxy</name>
+    <message>
+        <source>Application Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set up proxy servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>http</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>socks4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>socks5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IP Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check &quot;Use a proxy&quot; in application context menu in Launcher after configured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDSL</name>
+    <message>
+        <source>DSL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set up a dial-up network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add PPPoE connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDSLSettings</name>
+    <message>
+        <source> Network Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this configuration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDetails</name>
+    <message>
+        <source>Network Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View all network configurations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Details has been copied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Network Detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageHotspot</name>
+    <message>
+        <source>WPA/WPA2 Personal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WPA3 Personal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>2.4 GHz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>5 GHz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not Bind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Personal Hotspot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Share the network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>My Hotspot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit My Hotspot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name (SSID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Band</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shared Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hotspot Sharing Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you want to use the personal hotspot, disable Airplane Mode first and then enable the wireless network adapter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you want to use the personal hotspot, disable &lt;a style=&apos;text-decoration: none;&apos; href=&apos;network/airplaneMode&apos;&gt;Airplane Mode&lt;/a&gt; first and then enable the wireless network adapter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageSettings</name>
+    <message>
+        <source> Network Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this configuration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageSystemProxy</name>
+    <message>
+        <source>System Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set up proxy servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTTP Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTTPS Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FTP Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SOCKS Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore the proxy configurations for the above hosts and domains</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageVPN</name>
+    <message>
+        <source>VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect, add, import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*.conf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageVPNSettings</name>
+    <message>
+        <source> Network Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L2TP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPTP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OpenVPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OpenConnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StrongSwan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPNC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this configuration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*.conf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageWiredDevice</name>
+    <message>
+        <source>Connect, edit network settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug in the network cable first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Network Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageWirelessDevice</name>
+    <message>
+        <source>Connect, edit network settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>My&#xa0;Networks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Other Networks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable Airplane Mode first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable &lt;a style=&apos;text-decoration: none;&apos; href=&apos;network/airplaneMode&apos;&gt;Airplane Mode&lt;/a&gt; first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable hotspot first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;a style=&apos;text-decoration: none;&apos; href=&apos;NetHotspotControlItem&apos;&gt;Disable hotspot&lt;/a&gt; first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionDNS</name>
+    <message>
+        <source>DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionDevice</name>
+    <message>
+        <source>Not Bind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WLAN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ethernet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Device MAC Addr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cloned MAC Addr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Band</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>2.4 GHz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>5 GHz</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionGeneric</name>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name (SSID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionIPv4</name>
+    <message>
+        <source>IPv4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only applied in corresponding resources</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IP Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Netmask</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateway</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionIPv6</name>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only applied in corresponding resources</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IP Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prefix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateway</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionPPP</name>
+    <message>
+        <source>PPP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>128-bit MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stateful MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse EAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse PAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse CHAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse MSCHAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse MSCHAPv2 Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No BSD Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Deflate Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No TCP Header Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send PPP Echo Packets</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionPPPOE</name>
+    <message>
+        <source>PPPoE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Service</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionSecret</name>
+    <message>
+        <source>Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TLS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MD5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FAST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tunneled TLS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protected EAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MSCHAPV2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MSCHAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CHAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WEP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WPA/WPA2 Personal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WPA/WPA2 Enterprise</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WPA3 Personal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EAP Auth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Identity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pwd Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save password for this user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save password for all users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ask me always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Pwd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shared key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anonymous ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Provisioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anonymous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authenticated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PAC file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CA Cert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Cert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PEAP Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inner Auth</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionVPN</name>
+    <message>
+        <source>VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid gateway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CA Cert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow Cisco Secure Desktop Trojan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSD Script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auth Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SSH Agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Smart Card</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Shared Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Cert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use FSID for Key Passphrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Certificates (TLS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Certificates with Password (TLS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Static Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pwd Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ask</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Pwd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize Key Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Key Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remote IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Local IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NT Domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Request an Inner IP Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enforce UDP Encapsulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use IP Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Custom Cipher Proposals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IKE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ESP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Pwd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Hybrid Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CA File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN PPP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All Available (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>40-bit (less secure)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>128-bit (most secure)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stateful MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse EAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse PAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse CHAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse MSCHAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse MSCHAPv2 Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No BSD Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Deflate Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No TCP Header Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Protocol Field Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Address/Control Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send PPP Echo Packets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN IPsec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable IPsec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phase1 Algorithms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phase2 Algorithms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize Gateway Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateway Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize Renegotiation Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Renegotiation Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use LZO Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use TCP Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use TAP Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize Tunnel MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize UDP Fragment Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UDP Fragment Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restrict Tunnel TCP MSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Randomize Remote Hosts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cisco (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Netscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secure (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NAT Traversal Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NAT-T When Available (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NAT-T Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cisco UDP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IKE DH Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DH Group 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DH Group 2 (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DH Group 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Forward Secrecy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DH Group 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Local Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable Dead Peer Detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cipher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DES-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RC2-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DES-EDE-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DES-EDE3-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DESX-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BF-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RC2-40-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CAST5-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RC2-64-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES-128-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES-192-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES-256-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CAMELLIA-128-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CAMELLIA-192-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CAMELLIA-256-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SEED-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HMAC Auth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RSA MD-4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MD-5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-224</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-256</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-384</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-512</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RIPEMD-160</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTTP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SOCKS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Retry Indefinitely When Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN TLS Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subject Match</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remote Cert Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Client</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Key File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SystemProxyConfigItem</name>
+    <message>
+        <source>Optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authentication is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetAirplaneModeTipsItem</name>
+    <message>
+        <source>Disable &lt;a style=&quot;text-decoration: none;&quot; href=&quot;Airplane Mode&quot;&gt;Airplane Mode&lt;/a&gt; first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetManagerPrivate</name>
+    <message>
+        <source>IP conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetManagerThreadPrivate</name>
+    <message>
+        <source>Wired Connection %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN L2TP %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN PPTP %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN VPNC %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN OpenVPN %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN StrongSwan %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN OpenConnect %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPPoE Connection %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connecting &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;%1&quot; connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;%1&quot; disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to connect &quot;%1&quot;, please check your router or net cable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to connect &quot;%1&quot;, please keep closer to the wireless router</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connection failed, unable to connect &quot;%1&quot;, wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password is required to connect &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The &quot;%1&quot; 802.11 WLAN network could not be found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>To connect &quot;%1&quot;, please set up your authentication info after logging in</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetSystemProxyControlItem</name>
+    <message>
+        <source>System Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetVPNTipsItem</name>
+    <message>
+        <source>VPN configuration is not connected or failed to connect. Please &lt;a style=&quot;text-decoration: none;&quot; href=&quot;go to the control center&quot;&gt;go to the control center&lt;/a&gt; for inspection.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWiredControlItem</name>
+    <message>
+        <source>Wired Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWirelessControlItem</name>
+    <message>
+        <source>Wireless Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWirelessHiddenItem</name>
+    <message>
+        <source>Connect to hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWirelessMineItem</name>
+    <message>
+        <source>My Networks</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWirelessOtherItem</name>
+    <message>
+        <source>Other Networks</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>network</name>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/dcc-network/translations/network_en_US.ts
+++ b/dcc-network/translations/network_en_US.ts
@@ -1,3 +1,1725 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1"/>
+<TS version="2.1">
+<context>
+    <name>NetFileChooseEdit</name>
+    <message>
+        <source>All files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NetPasswordEdit</name>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageAirplane</name>
+    <message>
+        <source>Airplane mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stop wireless communication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enabling the airplane mode turns off wireless network, personal hotspot and Bluetooth</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageAppProxy</name>
+    <message>
+        <source>Application Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set up proxy servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>http</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>socks4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>socks5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IP Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Check &quot;Use a proxy&quot; in application context menu in Launcher after configured</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDSL</name>
+    <message>
+        <source>DSL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set up a dial-up network connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add PPPoE connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDSLSettings</name>
+    <message>
+        <source> Network Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this configuration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageDetails</name>
+    <message>
+        <source>Network Details</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>View all network configurations</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Details has been copied</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Select All</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Network Detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageHotspot</name>
+    <message>
+        <source>WPA/WPA2 Personal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WPA3 Personal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>2.4 GHz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>5 GHz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not Bind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Personal Hotspot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Share the network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>My Hotspot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit My Hotspot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name (SSID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Band</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shared Settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hotspot Sharing Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you want to use the personal hotspot, disable Airplane Mode first and then enable the wireless network adapter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>If you want to use the personal hotspot, disable &lt;a style=&apos;text-decoration: none;&apos; href=&apos;network/airplaneMode&apos;&gt;Airplane Mode&lt;/a&gt; first and then enable the wireless network adapter.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageSettings</name>
+    <message>
+        <source> Network Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this configuration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageSystemProxy</name>
+    <message>
+        <source>System Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set up proxy servers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Configuration URL</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTTP Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTTPS Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FTP Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SOCKS Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore the proxy configurations for the above hosts and domains</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageVPN</name>
+    <message>
+        <source>VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect, add, import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*.conf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Import Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>File error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OK</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageVPNSettings</name>
+    <message>
+        <source> Network Properties</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>L2TP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPTP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OpenVPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>OpenConnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>StrongSwan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPNC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Are you sure you want to delete this configuration?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>*.conf</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageWiredDevice</name>
+    <message>
+        <source>Connect, edit network settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Plug in the network cable first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Network Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PageWirelessDevice</name>
+    <message>
+        <source>Connect, edit network settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disconnect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>My&#xa0;Networks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Other Networks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable Airplane Mode first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable &lt;a style=&apos;text-decoration: none;&apos; href=&apos;network/airplaneMode&apos;&gt;Airplane Mode&lt;/a&gt; first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable hotspot first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&lt;a style=&apos;text-decoration: none;&apos; href=&apos;NetHotspotControlItem&apos;&gt;Disable hotspot&lt;/a&gt; first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionDNS</name>
+    <message>
+        <source>DNS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionDevice</name>
+    <message>
+        <source>Not Bind</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WLAN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ethernet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Device MAC Addr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cloned MAC Addr</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Band</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>2.4 GHz</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>5 GHz</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionGeneric</name>
+    <message>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name (SSID)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto Connect</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionIPv4</name>
+    <message>
+        <source>IPv4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only applied in corresponding resources</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IP Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Netmask</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateway</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionIPv6</name>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Manual</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ignore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IPv6</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Method</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Only applied in corresponding resources</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IP Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Prefix</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateway</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionPPP</name>
+    <message>
+        <source>PPP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>128-bit MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stateful MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse EAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse PAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse CHAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse MSCHAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse MSCHAPv2 Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No BSD Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Deflate Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No TCP Header Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send PPP Echo Packets</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionPPPOE</name>
+    <message>
+        <source>PPPoE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Service</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionSecret</name>
+    <message>
+        <source>Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>TLS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MD5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>FAST</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Tunneled TLS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Protected EAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>LEAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>GTC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MSCHAPV2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MSCHAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CHAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WEP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WPA/WPA2 Personal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WPA/WPA2 Enterprise</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>WPA3 Personal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EAP Auth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Identity</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pwd Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save password for this user</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save password for all users</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ask me always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Pwd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shared key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open system</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anonymous ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Provisioning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Anonymous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authenticated</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Both</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PAC file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CA Cert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Cert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PEAP Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Automatic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version 0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Inner Auth</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SectionVPN</name>
+    <message>
+        <source>VPN</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All files (*)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid gateway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateway</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CA Cert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Allow Cisco Secure Desktop Trojan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CSD Script</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auth Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SSH Agent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Smart Card</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>EAP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pre-Shared Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Cert</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use FSID for Key Passphrase</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Certificates (TLS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Certificates with Password (TLS)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Static Key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pwd Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ask</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Pwd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize Key Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Key Direction</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>0</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remote IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Local IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NT Domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Request an Inner IP Address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enforce UDP Encapsulation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use IP Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable Custom Cipher Proposals</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IKE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>ESP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Pwd</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use Hybrid Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CA File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN PPP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>All Available (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>40-bit (less secure)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>128-bit (most secure)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Stateful MPPE</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse EAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse PAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse CHAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse MSCHAP Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Refuse MSCHAPv2 Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No BSD Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Deflate Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No TCP Header Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Protocol Field Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>No Address/Control Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send PPP Echo Packets</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN IPsec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enable IPsec</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group ID</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phase1 Algorithms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phase2 Algorithms</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN Advanced</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize Gateway Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Gateway Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize Renegotiation Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Renegotiation Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use LZO Data Compression</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use TCP Connection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use TAP Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize Tunnel MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MTU</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Customize UDP Fragment Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>UDP Fragment Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restrict Tunnel TCP MSS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Randomize Remote Hosts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Domain</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Vendor</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cisco (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Netscreen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Encryption</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Secure (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Weak</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NAT Traversal Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NAT-T When Available (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>NAT-T Always</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cisco UDP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>IKE DH Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DH Group 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DH Group 2 (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DH Group 5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Forward Secrecy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DH Group 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Local Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable Dead Peer Detection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN Security</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cipher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Default</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DES-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RC2-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DES-EDE-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DES-EDE3-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>DESX-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>BF-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RC2-40-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CAST5-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RC2-64-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES-128-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES-192-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>AES-256-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CAMELLIA-128-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CAMELLIA-192-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>CAMELLIA-256-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SEED-CBC</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HMAC Auth</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RSA MD-4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>MD-5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-224</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-256</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-384</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SHA-512</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>RIPEMD-160</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Proxy Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>HTTP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>SOCKS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server IP</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Retry Indefinitely When Failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN TLS Authentication</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Subject Match</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remote Cert Type</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Client</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Key File</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SystemProxyConfigItem</name>
+    <message>
+        <source>Optional</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Authentication is required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Username</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetAirplaneModeTipsItem</name>
+    <message>
+        <source>Disable &lt;a style=&quot;text-decoration: none;&quot; href=&quot;Airplane Mode&quot;&gt;Airplane Mode&lt;/a&gt; first if you want to connect to a wireless network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetManagerPrivate</name>
+    <message>
+        <source>IP conflict</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetManagerThreadPrivate</name>
+    <message>
+        <source>Wired Connection %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN L2TP %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN PPTP %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN VPNC %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN OpenVPN %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN StrongSwan %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>VPN OpenConnect %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>PPPoE Connection %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connecting &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;%1&quot; connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>&quot;%1&quot; disconnected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to connect &quot;%1&quot;, please check your router or net cable.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unable to connect &quot;%1&quot;, please keep closer to the wireless router</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Connection failed, unable to connect &quot;%1&quot;, wrong password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Password is required to connect &quot;%1&quot;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The &quot;%1&quot; 802.11 WLAN network could not be found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>To connect &quot;%1&quot;, please set up your authentication info after logging in</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetSystemProxyControlItem</name>
+    <message>
+        <source>System Proxy</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetVPNTipsItem</name>
+    <message>
+        <source>VPN configuration is not connected or failed to connect. Please &lt;a style=&quot;text-decoration: none;&quot; href=&quot;go to the control center&quot;&gt;go to the control center&lt;/a&gt; for inspection.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWiredControlItem</name>
+    <message>
+        <source>Wired Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWirelessControlItem</name>
+    <message>
+        <source>Wireless Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWirelessHiddenItem</name>
+    <message>
+        <source>Connect to hidden network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWirelessMineItem</name>
+    <message>
+        <source>My Networks</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dde::network::NetWirelessOtherItem</name>
+    <message>
+        <source>Other Networks</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>network</name>
+    <message>
+        <source>Network</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
dcc-network 资源为空,导致翻译平台没有翻译资源,贡献者无法翻译.

## Summary by Sourcery

Fix empty translation resources for the dcc-network module by populating network_en.ts and network_en_US.ts with all source strings, enabling the translation platform to detect and translate network UI texts.

Bug Fixes:
- Restore missing source strings in dcc-network translation files to ensure the translation platform can detect translation entries.

Enhancements:
- Populate network_en.ts and network_en_US.ts with complete network context messages for translation.