### PR TITLE
fix: translation not loaded if language code not fully matched

### DIFF
--- a/dock-hotspot-plugin/hotspotplugin.cpp
+++ b/dock-hotspot-plugin/hotspotplugin.cpp
@@ -22,8 +22,9 @@ HotspotPlugin::HotspotPlugin(QObject *parent)
     : QObject(parent)
 {
   QTranslator *trs = new QTranslator(this);
-  trs->load(QString("/usr/share/dock-hotspot-plugin/translations/dock-hotspot-plugin_%1.qm").arg(QLocale::system().name()));
-  QCoreApplication::installTranslator(trs);
+  if (trs->load(QLocale(), "dock-hotspot-plugin", "_", "/usr/share/dock-hotspot-plugin/translations")) {
+    QCoreApplication::installTranslator(trs);
+  }
 }
 
 void HotspotPlugin::init(PluginProxyInterface *proxyInter) {

--- a/dock-network-plugin/networkplugin.cpp
+++ b/dock-network-plugin/networkplugin.cpp
@@ -42,7 +42,7 @@ NetworkPlugin::NetworkPlugin(QObject *parent)
     , m_netLimited(false)
 {
     QTranslator *translator = new QTranslator(this);
-    if (translator->load(QString("/usr/share/dock-network-plugin/translations/dock-network-plugin_%1").arg(QLocale().name()))) {
+    if (translator->load(QLocale(), "dock-network-plugin", "_", "/usr/share/dock-network-plugin/translations")) {
         QCoreApplication::installTranslator(translator);
     }
 }

--- a/dss-network-plugin/networkmodule.cpp
+++ b/dss-network-plugin/networkmodule.cpp
@@ -171,7 +171,7 @@ void NetworkModule::installTranslator(const QString &locale)
     }
     localTmp = locale;
     QApplication::removeTranslator(&translator);
-    translator.load(QString("/usr/share/dss-network-plugin/translations/dss-network-plugin_%1").arg(locale));
+    translator.load(QLocale(locale), "dss-network-plugin", "_", "/usr/share/dss-network-plugin/translations");
     QApplication::installTranslator(&translator);
     m_manager->updateLanguage(localTmp);
 }

--- a/network-service-plugin/system/networkinitialization.cpp
+++ b/network-service-plugin/system/networkinitialization.cpp
@@ -377,10 +377,12 @@ bool NetworkInitialization::installUserTranslator(const QString &json)
         localTmp = locale;
         static QTranslator translator;
         QCoreApplication::removeTranslator(&translator);
-        const QString qmFile = QString("%1/network-service-plugin_%2.qm").arg(QM_FILES_DIR).arg(locale);
-        translator.load(qmFile);
-        QCoreApplication::installTranslator(&translator);
-        qCDebug(DSM) << "install translation file" << qmFile;
+        if (translator.load(QLocale(locale), "network-service-plugin", "_", QM_FILES_DIR)) {
+            QCoreApplication::installTranslator(&translator);
+            qCInfo(DSM) << "Loaded translation file for network-service-plugin:" << translator.filePath();
+        } else {
+            qCWarning(DSM) << "Failed to load translation file for network-service-plugin with locale:" << locale;
+        }
     }
 
     return true;

--- a/src/networkcontroller.cpp
+++ b/src/networkcontroller.cpp
@@ -148,8 +148,14 @@ void NetworkController::installTranslator(const QString &locale)
     } else {
         m_translator = new QTranslator;
     }
-    m_translator->load(QString("/usr/share/dde-network-core/translations/dde-network-core_%1").arg(localeName));
-    QCoreApplication::installTranslator(m_translator);
+    if (m_translator->load(QLocale(localeName), "dde-network-core", "_", "/usr/share/dde-network-core/translations")) {
+        QCoreApplication::installTranslator(m_translator);
+        qInfo() << "Loaded translation file for dde-network-core:" << m_translator->filePath();
+    } else {
+        qWarning() << "Failed to load translation file for dde-network-core";
+        m_translator->deleteLater();
+        m_translator = nullptr;
+    }
 }
 
 void NetworkController::updateSync(const bool sync)


### PR DESCRIPTION
修正当系统语言代码与翻译资源的语言代码不完全匹配时(例如资源文件的语言代码中不包括地区代码部分),翻译资源不会被加载的问题.

## Summary by Sourcery

Improve translation loading across plugins to handle partial locale codes and provide logging on success or failure.

Bug Fixes:
- Ensure translation files load even when locale codes don’t exactly match resource filenames.

Enhancements:
- Standardize use of QTranslator::load(QLocale, baseName, separator, directory) in multiple modules.
- Add informational and warning logs for translation load success and failure.
- Clean up translator instances on load failure to prevent invalid installs.