### PR TITLE
feat(network): add full IPv6 DNS support and fix persistence issues

### DIFF
--- a/dcc-network/operation/dccnetwork.cpp
+++ b/dcc-network/operation/dccnetwork.cpp
@@ -65,32 +65,92 @@ void DccNetwork::exec(NetManager::CmdType cmd, const QString &id, const QVariant
                 const QVariantList &dnsData = ipData.value("dns").toList();
                 QList<uint> dns;
                 for (auto it : dnsData) {
-                    dns.append(it.toUInt());
+                    // 支持两种DNS格式：数字格式（IPv4）和字符串格式（IPv6）
+                    if (it.type() == QVariant::UInt || it.type() == QVariant::Int) {
+                        dns.append(it.toUInt());
+                    } else if (it.type() == QVariant::String) {
+                        QString dnsStr = it.toString();
+                        if (!dnsStr.isEmpty()) {
+                            // IPv6地址需要通过QHostAddress转换为数字表示
+                            QHostAddress addr(dnsStr);
+                            if (addr.protocol() == QAbstractSocket::IPv4Protocol) {
+                                // IPv4字符串转换为数字
+                                dns.append(addr.toIPv4Address());
+                            } else if (addr.protocol() == QAbstractSocket::IPv6Protocol) {
+                                // IPv6地址转换为128位表示（当前系统可能不支持，先跳过）
+                                qWarning() << "IPv6 DNS not fully implemented in backend, DNS:" << dnsStr;
+                                // 这里需要实现IPv6 DNS的完整支持
+                            }
+                        }
+                    }
                 }
                 ipData["dns"] = QVariant::fromValue(dns);
             }
             tmpParam["ipv4"] = QVariant::fromValue(ipData);
         }
-        if (param.contains("ipv6") && param.value("ipv6").toMap().contains("address-data")) {
-            const QVariantList &addressData = param.value("ipv6").toMap().value("address-data").toList();
-            QString gatewayStr = param.value("ipv6").toMap().value("gateway").toString();
-            IpV6DBusAddressList ipv6AddressList;
-            for (auto it : addressData) {
-                IpV6DBusAddress ipv6Address;
-                QVariantMap ipv6Data = it.toMap();
-                QHostAddress ip(ipv6Data.value("address").toString());
-                QIPv6Address ipv6Addr = ip.toIPv6Address();
-                QByteArray tmpAddress((char *)(ipv6Addr.c), 16);
-                ipv6Address.address = tmpAddress;
-                ipv6Address.prefix = ipv6Data.value("prefix").toUInt();
-                QHostAddress gateway(ipv6AddressList.isEmpty() ? gatewayStr : QString());
-                QByteArray tmpGateway((char *)(gateway.toIPv6Address().c), 16);
-                ipv6Address.gateway = tmpGateway;
-                ipv6AddressList.append(ipv6Address);
+        if (param.contains("ipv6")) {
+            QVariantMap ipv6Data = param.value("ipv6").toMap();
+            
+            // 处理IPv6地址
+            if (ipv6Data.contains("address-data")) {
+                const QVariantList &addressData = ipv6Data.value("address-data").toList();
+                QString gatewayStr = ipv6Data.value("gateway").toString();
+                IpV6DBusAddressList ipv6AddressList;
+                for (auto it : addressData) {
+                    IpV6DBusAddress ipv6Address;
+                    QVariantMap ipv6AddrData = it.toMap();
+                    QHostAddress ip(ipv6AddrData.value("address").toString());
+                    QIPv6Address ipv6Addr = ip.toIPv6Address();
+                    QByteArray tmpAddress((char *)(ipv6Addr.c), 16);
+                    ipv6Address.address = tmpAddress;
+                    ipv6Address.prefix = ipv6AddrData.value("prefix").toUInt();
+                    QHostAddress gateway(ipv6AddressList.isEmpty() ? gatewayStr : QString());
+                    QByteArray tmpGateway((char *)(gateway.toIPv6Address().c), 16);
+                    ipv6Address.gateway = tmpGateway;
+                    ipv6AddressList.append(ipv6Address);
+                }
+                ipv6Data["addresses"] = QVariant::fromValue(ipv6AddressList);
             }
-            QVariantMap ipData = param.value("ipv6").toMap();
-            ipData["addresses"] = QVariant::fromValue(ipv6AddressList);
-            tmpParam["ipv6"] = QVariant::fromValue(ipData);
+            
+            // 处理IPv6 DNS
+            if (ipv6Data.contains("dns")) {
+                const QVariantList &dnsData = ipv6Data.value("dns").toList();
+                QList<QHostAddress> ipv6DnsAddresses;
+                for (auto it : dnsData) {
+                    if (it.type() == QVariant::String) {
+                        QString dnsStr = it.toString();
+                        if (!dnsStr.isEmpty()) {
+                            QHostAddress addr(dnsStr);
+                            if (addr.protocol() == QAbstractSocket::IPv6Protocol) {
+                                ipv6DnsAddresses.append(addr);
+                            }
+                        }
+                    }
+                }
+                if (!ipv6DnsAddresses.isEmpty()) {
+                    // 直接使用字符串列表格式 - NetworkManager配置文件实际存储字符串
+                    QStringList ipv6DnsStrings;
+                    for (const QHostAddress &addr : ipv6DnsAddresses) {
+                        ipv6DnsStrings.append(addr.toString());
+                    }
+                    
+                    // 使用字符串列表格式保存IPv6 DNS
+                    ipv6Data["dns"] = ipv6DnsStrings;
+                    ipv6Data["ignore-auto-dns"] = true;
+                } else {
+                    // 没有有效的IPv6 DNS时，确保移除ignore-auto-dns设置
+                    // 这样系统可以恢复自动获取DNS
+                    ipv6Data.remove("dns");
+                    ipv6Data.remove("ignore-auto-dns");
+                }
+                
+                // 确保IPv6设置存在，即使没有DNS也要设置，以便被正确处理
+                if (ipv6Data.isEmpty()) {
+                    ipv6Data["method"] = "auto";  // 至少设置一个值确保IPv6部分存在
+                }
+            }
+            
+            tmpParam["ipv6"] = QVariant::fromValue(ipv6Data);
         }
         m_manager->exec(cmd, id, tmpParam);
     } break;

--- a/dcc-network/qml/PageSettings.qml
+++ b/dcc-network/qml/PageSettings.qml
@@ -76,7 +76,15 @@ DccObject {
         sectionSecret.setConfig802_1x(config["802-1x"])
         sectionIPv4.setConfig(config.ipv4)
         sectionIPv6.setConfig(config.ipv6)
-        sectionDNS.setConfig((config.hasOwnProperty("ipv4") && config.ipv4.hasOwnProperty("dns")) ? config.ipv4.dns : null)
+        // 合并IPv4和IPv6的DNS配置
+        let combinedDns = []
+        if (config.hasOwnProperty("ipv4") && config.ipv4.hasOwnProperty("dns") && config.ipv4.dns.length > 0) {
+            combinedDns = combinedDns.concat(config.ipv4.dns)
+        }
+        if (config.hasOwnProperty("ipv6") && config.ipv6.hasOwnProperty("dns") && config.ipv6.dns.length > 0) {
+            combinedDns = combinedDns.concat(config.ipv6.dns)
+        }
+        sectionDNS.setConfig(combinedDns.length > 0 ? combinedDns : null)
         sectionDevice.type = type
         sectionDevice.setConfig(config[config.connection.type])
         modified = config.connection.uuid === "{00000000-0000-0000-0000-000000000000}" && sectionGeneric.settingsID.length !== 0
@@ -197,7 +205,28 @@ DccObject {
                     if (nConfig["ipv4"] === undefined) {
                         nConfig["ipv4"] = {}
                     }
-                    nConfig["ipv4"]["dns"] = sectionDNS.getConfig()
+                    if (nConfig["ipv6"] === undefined) {
+                        nConfig["ipv6"] = {}
+                    }
+                    
+                    // 获取DNS配置并分离IPv4和IPv6
+                    let dnsConfig = sectionDNS.getConfig()
+                    let ipv4Dns = []
+                    let ipv6Dns = []
+                    
+                    for (let dns of dnsConfig) {
+                        if (typeof dns === 'number') {
+                            // IPv4 DNS（数字格式）
+                            ipv4Dns.push(dns)
+                        } else if (typeof dns === 'string') {
+                            // IPv6 DNS（字符串格式）
+                            ipv6Dns.push(dns)
+                        }
+                    }
+                    
+                    // 分别保存到IPv4和IPv6配置中
+                    nConfig["ipv4"]["dns"] = ipv4Dns
+                    nConfig["ipv6"]["dns"] = ipv6Dns
                     let devConfig = sectionDevice.getConfig()
                     if (devConfig.interfaceName.length === 0) {
                         delete nConfig["connection"]["interface-name"]

--- a/dcc-network/qml/SectionDNS.qml
+++ b/dcc-network/qml/SectionDNS.qml
@@ -28,8 +28,13 @@ DccObject {
             let tmpConfig = []
             for (var i in c) {
                 if (c[i] !== 0) {
-                    let ip = NetUtils.numToIp(c[i])
-                    tmpConfig.push(ip)
+                    // 支持两种格式：数字格式（旧的IPv4）和字符串格式（新的IPv4/IPv6）
+                    if (typeof c[i] === 'number') {
+                        let ip = NetUtils.numToIp(c[i])
+                        tmpConfig.push(ip)
+                    } else if (typeof c[i] === 'string' && c[i].length > 0) {
+                        tmpConfig.push(c[i])
+                    }
                 }
             }
             while (tmpConfig.length < 2) {
@@ -39,24 +44,66 @@ DccObject {
         }
     }
     function getConfig() {
-        let saveData = []
+        console.log("[DNS-GetConfig] Starting DNS config processing, raw config:", root.config)
+        let ipv4Data = []
+        let ipv6Data = []
+        
         for (var ip of root.config) {
-            let ipNum = NetUtils.ipToNum(ip)
-            if (ipNum !== 0) {
-                saveData.push(ipNum)
+            if (ip !== "") {
+                console.log("[DNS-GetConfig] Processing IP:", ip)
+                // 检查是否为有效的IP地址（IPv4或IPv6）
+                if (NetUtils.isValidIpAddress(ip)) {
+                    if (NetUtils.isIpv4Address(ip)) {
+                        // IPv4 DNS保存为数字格式
+                        let ipNum = NetUtils.ipToNum(ip)
+                        console.log("[DNS-GetConfig] IPv4 processed:", ip, "->", ipNum)
+                        if (ipNum !== 0) {
+                            ipv4Data.push(ipNum)
+                        }
+                    } else if (NetUtils.isIpv6Address(ip)) {
+                        // IPv6 DNS保存为字符串格式
+                        console.log("[DNS-GetConfig] IPv6 processed:", ip)
+                        ipv6Data.push(ip)
+                    }
+                } else {
+                    console.log("[DNS-GetConfig] Invalid IP address:", ip)
+                }
+            } else {
+                console.log("[DNS-GetConfig] Empty IP skipped")
             }
         }
+        
+        // 返回混合数据，后端会根据类型分别处理
+        let saveData = []
+        for (let ipv4 of ipv4Data) {
+            saveData.push(ipv4)
+        }
+        for (let ipv6 of ipv6Data) {
+            saveData.push(ipv6)
+        }
+        
+        console.log("[DNS-GetConfig] Final save data:", saveData, "IPv4:", ipv4Data, "IPv6:", ipv6Data)
         return saveData
     }
     function checkInput() {
+        console.log("[DNS-Check] Starting DNS validation, config:", root.config)
         errorKey = ""
         for (var i in root.config) {
-            if (root.config[i] !== "" && !NetUtils.ipRegExp.test(root.config[i])) {
-                errorKey = "dns" + i
-                return false
+            if (root.config[i] !== "") {
+                console.log("[DNS-Check] Validating DNS entry", i, ":", root.config[i])
+                if (!NetUtils.isValidIpAddress(root.config[i])) {
+                    console.log("[DNS-Check] Validation failed for DNS entry", i, ":", root.config[i])
+                    errorKey = "dns" + i
+                    return false
+                } else {
+                    console.log("[DNS-Check] Validation passed for DNS entry", i, ":", root.config[i])
+                }
+            } else {
+                console.log("[DNS-Check] Empty DNS entry", i, "skipped")
             }
         }
 
+        console.log("[DNS-Check] All DNS entries validated successfully")
         return true
     }
 
@@ -106,14 +153,16 @@ DccObject {
             page: RowLayout {
                 D.LineEdit {
                     text: root.config[index]
-                    validator: RegularExpressionValidator {
-                        regularExpression: NetUtils.ipRegExp
-                    }
+                    // 移除正则验证器，改用手动验证以支持IPv6
+                    // 显式允许所有字符输入，包括冒号
+                    inputMethodHints: Qt.ImhNone
                     onTextChanged: {
+                        console.log("[DNS-Input] Text changed in DNS field", index, ":", text)
                         if (showAlert) {
                             errorKey = ""
                         }
                         if (text !== root.config[index]) {
+                            console.log("[DNS-Input] Updating config[" + index + "] from", root.config[index], "to", text)
                             root.config[index] = text
                             root.editClicked()
                         }


### PR DESCRIPTION
- Implement IPv6 validation in NetUtils.js for DNS input fields
- Fix backend storage in dccnetwork.cpp to use QHostAddress format
- Add ignore-auto-dns=true setting for proper NetworkManager persistence
- Update frontend QML components to handle mixed IPv4/IPv6 DNS
- Enhance netmanagerthreadprivate.cpp to read IPv6 DNS from NM settings

Fixes issues with IPv6 DNS input, saving and display in Control Center.

pms: BUG-319129

## Summary by Sourcery

Enable comprehensive IPv6 DNS support and persistence by updating validation, UI, backend storage, and NetworkManager settings handling

New Features:
- Support mixed IPv4/IPv6 DNS inputs and storage in both frontend QML components and backend DccNetwork
- Implement IPv6 validation functions in NetUtils.js to validate and differentiate IPv4 vs IPv6 addresses
- Fetch and apply manual IPv6 gateway and DNS from NetworkManager settings in NetManagerThreadPrivate

Bug Fixes:
- Fix persistence of custom IPv6 DNS by setting ignore-auto-dns on the IPv6 setting
- Correct backend storage of DNS entries to use QHostAddress formats for both IPv4 and IPv6

Enhancements:
- Merge IPv4 and IPv6 DNS entries in settings pages and separate them on save
- Remove regex-only validation in QML and unify IP validation logic for robust IPv6 support