### PR TITLE
chore: release dde-network-core 2.0.60

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-network-core (2.0.60) unstable; urgency=medium
+
+  * chore: Modify compilation issues
+  * i18n: Update translations
+
+ -- Wang Zichong <wangzichong@deepin.org>  Sat, 21 Jun 2025 13:42:00 +0800
+
 dde-network-core (2.0.59) unstable; urgency=medium
 
   * feat(network): add full IPv6 DNS support and fix persistence issues


### PR DESCRIPTION
Changelog:

  * chore: Modify compilation issues
  * i18n: Update translations

Log:

## Summary by Sourcery

Prepare and release dde-network-core version 2.0.60 with compilation fixes and updated translations.

Enhancements:
- Fix compilation issues
- Update i18n translations

Chores:
- Update Debian changelog for version 2.0.60