### PR TITLE
chore: bump version to 2.0.60

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-network-core (2.0.60) unstable; urgency=medium
+
+  * chore: remove reginal variants for es language
+  * i18n: Translate network_en_US.ts in es (#360)
+  * i18n: Updates for project Deepin Desktop Environment (#359)
+  * i18n: Updates for project Deepin Desktop Environment (#353)
+  * chore: Modify compilation issues
+
+ -- caixiangrong <caixiangrong@uniontech.com>  Thu, 12 Jun 2025 16:20:40 +0800
+
 dde-network-core (2.0.59) unstable; urgency=medium
 
   * feat(network): add full IPv6 DNS support and fix persistence issues


### PR DESCRIPTION
update changelog to 2.0.60

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 2.0.60.