### PR TITLE
fix: SpinBox supports keyboard input

### DIFF
--- a/dcc-network/qml/SectionDevice.qml
+++ b/dcc-network/qml/SectionDevice.qml
@@ -180,6 +180,7 @@ DccTitleObject {
             visible: hasMTU
             pageType: DccObject.Editor
             page: D.SpinBox {
+                editable: true
                 value: root.config.hasOwnProperty("mtu") ? root.config.mtu : 0
                 onValueChanged: {
                     if (hasMTU && (!root.config.hasOwnProperty("mtu") || root.config.mtu !== value)) {

--- a/dcc-network/qml/SectionIPv6.qml
+++ b/dcc-network/qml/SectionIPv6.qml
@@ -321,6 +321,7 @@ DccObject {
                     displayName: qsTr("Prefix")
                     pageType: DccObject.Editor
                     page: D.SpinBox {
+                        editable: true
                         value: root.addressData.length > index ? root.addressData[index].prefix : 64
                         from: 0
                         to: 128

--- a/dcc-network/qml/SectionVPN.qml
+++ b/dcc-network/qml/SectionVPN.qml
@@ -1458,6 +1458,7 @@ DccTitleObject {
             visible: root.dataMap.hasOwnProperty("port")
             pageType: DccObject.Editor
             page: D.SpinBox {
+                editable: true
                 value: root.dataMap.hasOwnProperty(dccObj.name) ? parseInt(root.dataMap[dccObj.name], 10) : 1194
                 from: 0
                 to: 65535
@@ -1496,6 +1497,7 @@ DccTitleObject {
             visible: root.dataMap.hasOwnProperty("reneg-seconds")
             pageType: DccObject.Editor
             page: D.SpinBox {
+                editable: true
                 value: root.dataMap.hasOwnProperty(dccObj.name) ? parseInt(root.dataMap[dccObj.name], 10) : 0
                 from: 0
                 to: 65535
@@ -1569,6 +1571,7 @@ DccTitleObject {
             visible: root.dataMap.hasOwnProperty("tunnel-mtu")
             pageType: DccObject.Editor
             page: D.SpinBox {
+                editable: true
                 value: root.dataMap.hasOwnProperty(dccObj.name) ? parseInt(root.dataMap[dccObj.name], 10) : 1500
                 from: 0
                 to: 65535
@@ -1607,6 +1610,7 @@ DccTitleObject {
             visible: root.dataMap.hasOwnProperty("fragment-size")
             pageType: DccObject.Editor
             page: D.SpinBox {
+                editable: true
                 value: root.dataMap.hasOwnProperty(dccObj.name) ? parseInt(root.dataMap[dccObj.name], 10) : 1300
                 from: 0
                 to: 65535
@@ -1819,6 +1823,7 @@ DccTitleObject {
             weight: 80
             pageType: DccObject.Editor
             page: D.SpinBox {
+                editable: true
                 value: root.dataMap.hasOwnProperty(dccObj.name) ? parseInt(root.dataMap[dccObj.name], 10) : 0
                 from: 0
                 to: 65535
@@ -2048,6 +2053,7 @@ DccTitleObject {
             visible: root.dataMap["proxy-type"] !== "none"
             pageType: DccObject.Editor
             page: D.SpinBox {
+                editable: true
                 value: root.dataMap.hasOwnProperty(dccObj.name) ? parseInt(root.dataMap[dccObj.name], 10) : 0
                 from: 0
                 to: 65535


### PR DESCRIPTION
SpinBox supports keyboard input

pms: BUG-286729

## Summary by Sourcery

Allow direct keyboard input in SpinBox controls by marking them as editable across VPN, Device, and IPv6 configuration sections.

Bug Fixes:
- Enable editable property on SpinBox components in SectionVPN.qml for port, reneg-seconds, tunnel-mtu, fragment-size, and additional fields
- Set editable: true on the MTU SpinBox in SectionDevice.qml
- Enable editable SpinBox for prefix values in SectionIPv6.qml