### PR TITLE
fix: Duplicate IP addresses do not prompt error messages

### DIFF
--- a/dcc-network/qml/SectionIPv4.qml
+++ b/dcc-network/qml/SectionIPv4.qml
@@ -20,7 +20,8 @@ DccObject {
     property bool isEdit: false
     property string method: "auto"
 
-    property string errorKey: ""
+    property string errorKey: "" 
+    property string errorMsg: ""
     signal editClicked
 
     function setConfig(c) {
@@ -53,20 +54,35 @@ DccObject {
     }
     function checkInput() {
         errorKey = ""
+        errorMsg = ""
         if (method === "manual") {
             for (let k in addressData) {
                 if (!NetUtils.ipRegExp.test(addressData[k][0])) {
                     errorKey = k + "address"
+                    errorMsg = qsTr("Invalid IP address")
                     return false
                 }
                 if (!NetUtils.maskRegExp.test(addressData[k][1])) {
                     errorKey = k + "prefix"
+                    errorMsg = qsTr("Invalid netmask")
                     return false
                 }
                 if (addressData[k][2].length !== 0 && !NetUtils.ipRegExp.test(addressData[k][2])) {
                     errorKey = k + "gateway"
+                    errorMsg = qsTr("Invalid gateway")
                     return false
                 }
+            }
+            let ipSet = new Set()
+            for (let k in addressData) {
+                if (!addressData[k] || !addressData[k][0]) continue;
+                let ip = addressData[k][0]
+                if (ipSet.has(ip)) {
+                    errorKey = k + "address"
+                    errorMsg = qsTr("Duplicate IP address")
+                    return false
+                }
+                ipSet.add(ip)
             }
         }
         return true
@@ -288,7 +304,7 @@ DccObject {
                         }
                         showAlert: errorKey === index + dccObj.name
                         alertDuration: 2000
-                        alertText: qsTr("Invalid IP address")
+                        alertText: errorKey === index + dccObj.name ? root.errorMsg : ""
                         onShowAlertChanged: {
                             if (showAlert) {
                                 DccApp.showPage(dccObj)

--- a/dcc-network/qml/SectionIPv6.qml
+++ b/dcc-network/qml/SectionIPv6.qml
@@ -22,6 +22,7 @@ DccObject {
     property string gateway: ""
 
     property string errorKey: ""
+    property string errorMsg: ""
     signal editClicked
 
     function setConfig(c) {
@@ -47,18 +48,30 @@ DccObject {
     }
     function checkInput() {
         errorKey = ""
+        errorMsg = ""
         if (method === "manual") {
+            let ipSet = new Set()
             for (let k in addressData) {
                 if (!NetUtils.ipv6RegExp.test(addressData[k].address)) {
                     errorKey = k + "address"
+                    errorMsg = qsTr("Invalid IP address")
                     return false
                 }
                 if (addressData[k].prefix < 0 || addressData[k].prefix > 128) {
                     errorKey = k + "prefix"
+                    errorMsg = qsTr("Invalid netmask")
                     return false
                 }
+                let ip = addressData[k].address
+                if (ipSet.has(ip) && ip !== "") {
+                    errorKey = k + "address"
+                    errorMsg = qsTr("Duplicate IP address")
+                    return false
+                }
+                // 检查网关
                 if (k === "0" && gateway.length !== 0 && !NetUtils.ipv6RegExp.test(gateway)) {
                     errorKey = k + "gateway"
+                    errorMsg = qsTr("Invalid gateway")
                     return false
                 }
             }
@@ -292,7 +305,7 @@ DccObject {
                         }
                         showAlert: errorKey === index + dccObj.name
                         alertDuration: 2000
-                        alertText: qsTr("Invalid IP address")
+                        alertText: errorKey === index + dccObj.name ? root.errorMsg : ""
                         onShowAlertChanged: {
                             if (showAlert) {
                                 DccApp.showPage(dccObj)
@@ -324,6 +337,7 @@ DccObject {
                         }
                         showAlert: errorKey === index + dccObj.name
                         alertDuration: 2000
+                        alertText: errorKey === index + dccObj.name ? root.errorMsg : ""
                         onShowAlertChanged: {
                             if (showAlert) {
                                 DccApp.showPage(dccObj)
@@ -355,7 +369,7 @@ DccObject {
                         }
                         showAlert: errorKey === index + dccObj.name
                         alertDuration: 2000
-                        alertText: qsTr("Invalid IP address")
+                        alertText: errorKey === index + dccObj.name ? root.errorMsg : ""
                         onShowAlertChanged: {
                             if (showAlert) {
                                 DccApp.showPage(dccObj)


### PR DESCRIPTION
Add duplicate IP validation and improved error messages for IPv4/IPv6 config ﻿
- Implement duplicate IP address detection in manual configuration for both IPv4 and IPv6
- Add specific error messages for different validation failures (invalid IP, netmask, gateway, duplicates)
- Introduce errorMsg property to store localized error descriptions
- Update alertText to show context-specific error messages
- Maintain existing validation checks while enhancing error reporting

pms: BUG-312367