### PR TITLE
fix: fix safe build with debian/rules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,11 +8,6 @@ project(dde-network-core
   LANGUAGES CXX C
 )
 
-# 增加安全编译参数
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all")
-set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -z relro -z now -z noexecstack -pie")
-
 option(ENABLE_DEEPIN_NMQT "enable nmqt patch on deepin" OFF)
 
 set(DDE-Network-Core_INCLUDE_DIRS  "${CMAKE_SOURCE_DIR}/src-old")

--- a/debian/rules
+++ b/debian/rules
@@ -2,6 +2,10 @@
 include /usr/share/dpkg/default.mk
 
 export QT_SELECT = qt5
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack -Wl,-E
 
 DISTRO = $(shell lsb_release -is)
 ifeq ($(DISTRO),Deepin)


### PR DESCRIPTION
as title.

Logs:

## Summary by Sourcery

Move security hardening flags from CMake configuration into Debian packaging rules to ensure a safe build environment under Debian.

Enhancements:
- Remove explicit -fstack-protector-all and linker security flags from CMakeLists.txt

Build:
- Add security hardening flags in debian/rules for safe builds