### PR TITLE
fix: Use the system default language when unable to retrieve users

### DIFF
--- a/dss-network-plugin/networkmodule.cpp
+++ b/dss-network-plugin/networkmodule.cpp
@@ -171,8 +171,9 @@ void NetworkModule::installTranslator(const QString &locale)
     }
     localTmp = locale;
     QApplication::removeTranslator(&translator);
-    translator.load(QLocale(locale), "dss-network-plugin", "_", "/usr/share/dss-network-plugin/translations");
-    QApplication::installTranslator(&translator);
+    if (translator.load(QLocale(locale), "dss-network-plugin", "_", "/usr/share/dss-network-plugin/translations")) {
+        QApplication::installTranslator(&translator);
+    }
     m_manager->updateLanguage(localTmp);
 }
 

--- a/network-service-plugin/system/networkinitialization.h
+++ b/network-service-plugin/system/networkinitialization.h
@@ -37,6 +37,8 @@ private:
     bool hasConnection(const QSharedPointer<NetworkManager::WiredDevice> &device, QList<QSharedPointer<NetworkManager::Connection>> &unSaveDevices);
     QString connectionMatchName() const;
     bool installUserTranslator(const QString &json);
+    bool installTranslator(const QString &locale);
+    bool installSystemTranslator();
     void hideWirelessDevice(const QSharedPointer<NetworkManager::Device> &device, bool disableNetwork);
     void initDeviceConnection(const QSharedPointer<NetworkManager::WiredDevice> &device);
     void checkAccountStatus();


### PR DESCRIPTION
Use the system default language when unable to retrieve users

pms: BUG-286715

## Summary by Sourcery

Use the system’s default locale as a fallback when user-specific language data is unavailable, and ensure translators are only installed upon successful loading.

Bug Fixes:
- Fallback to system default language when current user cannot be retrieved

Enhancements:
- Add installSystemTranslator to parse /etc/locale.conf and apply system locale
- Extract installTranslator helper and update initConnection to invoke system fallback
- Guard translation installation to only occur if translator.load succeeds