### PR TITLE
fix: Compatible with installer plugin processing

### DIFF
--- a/dss-network-plugin/networkmodule.cpp
+++ b/dss-network-plugin/networkmodule.cpp
@@ -40,7 +40,7 @@ NetworkModule::NetworkModule(QObject *parent)
     , m_replacesId(0)
     , m_contentWidget(new QWidget)
 {
-    m_isLockModel = !QCoreApplication::applicationName().contains("greeter");
+    m_isLockModel = QCoreApplication::applicationName().contains("lock", Qt::CaseInsensitive);
 
     m_contentWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
     QVBoxLayout *mainLayout = new QVBoxLayout(m_contentWidget);


### PR DESCRIPTION
Compatible with installer plugin processing

pms: BUG-323021

## Summary by Sourcery

Bug Fixes:
- Use a case-insensitive check for "lock" in the application name to set m_isLockModel instead of excluding "greeter"