### PR TITLE
chore: bump version to 2.0.62

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+dde-network-core (2.0.62) unstable; urgency=medium
+
+  * fix: Compatible with installer plugin processingd3f2aed [dde-network-core] Updates for project Deepin Desktop Environment (#374)
+  * fix: DSL connection deletion signal processing error
+  * fix: Use the system default language when unable to retrieve users
+  * chore: Update translation
+
+ -- caixiangrong <caixiangrong@uniontech.com>  Thu, 10 Jul 2025 11:25:40 +0800
+
 dde-network-core (2.0.61) unstable; urgency=medium
 
   * fix: fix safe build with debian/rules.


### PR DESCRIPTION
update changelog to 2.0.62

## Summary by Sourcery

Bump plugin to version 2.0.62, correct lock model detection, and update changelog.

Bug Fixes:
- Correct m_isLockModel initialization to depend on ‘lock’ keyword in application name.

Build:
- Bump version to 2.0.62.

Documentation:
- Update Debian changelog for version 2.0.62.