### PR TITLE
chore: bump version to 2.0.62

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-network-core (2.0.63) unstable; urgency=medium
+
+  * i18n: Updates for project Deepin Desktop Environment (#379)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 16 Jul 2025 10:28:05 +0800
+
 dde-network-core (2.0.62) unstable; urgency=medium
 
   * fix: Compatible with installer plugin processingd3f2aed [dde-network-core] Updates for project Deepin Desktop Environment (#374)


### PR DESCRIPTION
update changelog to 2.0.62

## Summary by Sourcery

Chores:
- Update debian/changelog entry for version 2.0.62