### PR TITLE
fix: Network detection button display issue

### DIFF
--- a/dcc-network/operation/dccnetwork.cpp
+++ b/dcc-network/operation/dccnetwork.cpp
@@ -165,6 +165,15 @@ void DccNetwork::setClipboard(const QString &text)
     QGuiApplication::clipboard()->setText(text);
 }
 
+bool DccNetwork::netCheckAvailable()
+{
+    if (!m_manager) {
+        return false;
+    }
+    
+    return m_manager->netCheckAvailable();
+}
+
 QVariantMap DccNetwork::toMap(QMap<QString, QString> map)
 {
     QVariantMap retMap;

--- a/dcc-network/operation/dccnetwork.h
+++ b/dcc-network/operation/dccnetwork.h
@@ -31,6 +31,7 @@ public:
 public Q_SLOTS:
     void exec(NetManager::CmdType cmd, const QString &id, const QVariantMap &param = QVariantMap()); // 执行操作
     void setClipboard(const QString &text);
+    bool netCheckAvailable(); // 检查网络检测功能是否可用
 
     QVariantMap toMap(QMap<QString, QString> map);
     QMap<QString, QString> toStringMap(QVariantMap map);

--- a/dcc-network/qml/PageDetails.qml
+++ b/dcc-network/qml/PageDetails.qml
@@ -164,6 +164,7 @@ DccObject {
             parentName: root.name + "/footer"
             weight: 40
             pageType: DccObject.Item
+            visible: dccData.netCheckAvailable()
             page: NetButton {
                 text: qsTr("Network Detection")
                 Layout.alignment: Qt.AlignRight


### PR DESCRIPTION
add network availability check function

1. Added netCheckAvailable() method to DccNetwork class to verify network detection capability
2. Implemented the method to check if network manager exists before performing availability check
3. Modified PageDetails.qml to conditionally show Network Detection button based on availability
4. This change prevents UI elements from appearing when network detection is not supported

feat: 添加网络可用性检查功能

1. 在DccNetwork类中添加netCheckAvailable()方法用于验证网络检测功能
2. 实现方法在检查可用性前先验证网络管理器是否存在
3. 修改PageDetails.qml根据可用性条件显示网络检测按钮
4. 此变更防止在网络检测不被支持时显示UI元素

pms: BUG-303731

## Summary by Sourcery

Add a network availability check in DccNetwork and update the UI to conditionally display the network detection button only when supported

New Features:
- Add netCheckAvailable method to DccNetwork to verify network detection support

Bug Fixes:
- Prevent network detection button from appearing when network detection is not supported

Enhancements:
- Use netCheckAvailable in PageDetails.qml to show the network detection button only if available