### PR TITLE
fix: Network list display issue

### DIFF
--- a/dcc-network/qml/PageWiredDevice.qml
+++ b/dcc-network/qml/PageWiredDevice.qml
@@ -90,7 +90,7 @@ DccObject {
 
                         delegate: ItemDelegate {
                             id: itemDelegate
-                            implicitHeight: 36
+                            height: 36
                             text: model.item.name
                             // icon.name: model.icon
                             hoverEnabled: true
@@ -99,9 +99,18 @@ DccObject {
                             corners: getCornersForBackground(index, repeater.count)
                             cascadeSelected: true
                             Layout.fillWidth: true
-                            icon.name: "network-online-symbolic"
-                            // "network-setting"
+                            leftPadding: 10
+                            rightPadding: 0   // 移除右边距，让箭头区域能扩展到边缘
+                            topPadding: 0     // 恢复适量上边距
+                            bottomPadding: 0  // 恢复适量下边距
+                            spacing: 10
+                            icon {
+                                name: "network-online-symbolic"
+                                height: 16
+                                width: 16
+                            }
                             content: RowLayout {
+                                spacing: 10
                                 BusyIndicator {
                                     running: model.item.status === NetType.CS_Connecting
                                     visible: running
@@ -120,16 +129,87 @@ DccObject {
                                         dccData.exec(model.item.status === NetType.CS_Connected ? NetManager.Disconnect : NetManager.ConnectOrInfo, model.item.id, {})
                                     }
                                 }
-                                D.IconLabel {
-                                    icon {
-                                        name: "arrow_ordinary_right"
-                                        palette: D.DTK.makeIconPalette(palette)
+                                
+                                // 箭头悬浮效果 - 右侧圆角（包含分割线）
+                                Item {
+                                    width: 30  // 20px悬浮区域 + 10px扩展到边缘
+                                    height: 40 // 填满ItemDelegate高度
+                                    
+                                    Canvas {
+                                        id: hoverCanvas
+                                        anchors.fill: parent
+                                        property color bgColor: "transparent"
+                                        
+                                        onPaint: {
+                                            var ctx = getContext("2d")
+                                            ctx.clearRect(0, 0, width, height)
+                                            
+                                            if (bgColor.a > 0) {
+                                                ctx.fillStyle = bgColor
+                                                ctx.beginPath()
+                                                
+                                                // 绘制右侧圆角的矩形
+                                                ctx.moveTo(0, 0)                           // 左上角
+                                                ctx.lineTo(width - 6, 0)                  // 右上角前
+                                                ctx.arcTo(width, 0, width, 6, 6)          // 右上圆角
+                                                ctx.lineTo(width, height - 6)             // 右下角前
+                                                ctx.arcTo(width, height, width - 6, height, 6) // 右下圆角
+                                                ctx.lineTo(0, height)                     // 左下角
+                                                ctx.lineTo(0, 0)                          // 回到左上角
+                                                
+                                                ctx.fill()
+                                            }
+                                        }
+                                        
+                                        onBgColorChanged: requestPaint()
                                     }
+                                    
+                                    // 分割线 - 一直显示
+                                    Rectangle {
+                                        width: 1
+                                        height: 20
+                                        anchors.left: parent.left
+                                        anchors.leftMargin: 0   // 在悬浮区域最左边
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        color: palette.windowText
+                                        opacity: 0.05
+                                    }
+                                    
+                                    D.IconLabel {
+                                        anchors.centerIn: parent
+                                        icon {
+                                            name: "arrow_ordinary_right"
+                                            palette: D.DTK.makeIconPalette(palette)
+                                        }
+                                    }
+                                    
                                     MouseArea {
                                         anchors.fill: parent
+                                        hoverEnabled: true
                                         acceptedButtons: Qt.LeftButton
+                                        
                                         onClicked: {
                                             dccData.exec(NetManager.ConnectInfo, model.item.id, {})
+                                        }
+                                        
+                                        onEntered: {
+                                            hoverCanvas.bgColor = Qt.rgba(palette.windowText.r, palette.windowText.g, palette.windowText.b, 0.1)
+                                        }
+                                        
+                                        onExited: {
+                                            hoverCanvas.bgColor = "transparent"
+                                        }
+                                        
+                                        onPressed: {
+                                            hoverCanvas.bgColor = Qt.rgba(palette.windowText.r, palette.windowText.g, palette.windowText.b, 0.2)
+                                        }
+                                        
+                                        onReleased: {
+                                            if (containsMouse) {
+                                                hoverCanvas.bgColor = Qt.rgba(palette.windowText.r, palette.windowText.g, palette.windowText.b, 0.1)
+                                            } else {
+                                                hoverCanvas.bgColor = "transparent"
+                                            }
                                         }
                                     }
                                 }

--- a/dcc-network/qml/PageWirelessDevice.qml
+++ b/dcc-network/qml/PageWirelessDevice.qml
@@ -66,7 +66,9 @@ DccObject {
                             cascadeSelected: true
                             Layout.fillWidth: true
                             leftPadding: 10
-                            rightPadding: 10
+                            rightPadding: 0   // 移除右边距，让箭头区域能扩展到边缘
+                            topPadding: 0     // 恢复适量上边距
+                            bottomPadding: 0  // 恢复适量下边距
                             spacing: 10
                             icon {
                                 name: "network-wireless" + (item.flags ? "-6" : "") + c_levelString[item.strengthLevel] + (item.secure ? "-secure" : "") + "-symbolic"
@@ -93,16 +95,87 @@ DccObject {
                                         dccData.exec(model.item.status === NetType.CS_Connected ? NetManager.Disconnect : NetManager.ConnectOrInfo, model.item.id, {})
                                     }
                                 }
-                                D.IconLabel {
-                                    icon {
-                                        name: "arrow_ordinary_right"
-                                        palette: D.DTK.makeIconPalette(palette)
+                                
+                                // 箭头悬浮效果 - 右侧圆角（包含分割线）
+                                Item {
+                                    width: 30  // 20px悬浮区域 + 10px扩展到边缘
+                                    height: 40 // 填满ItemDelegate高度
+                                    
+                                    Canvas {
+                                        id: hoverCanvas
+                                        anchors.fill: parent
+                                        property color bgColor: "transparent"
+                                        
+                                        onPaint: {
+                                            var ctx = getContext("2d")
+                                            ctx.clearRect(0, 0, width, height)
+                                            
+                                            if (bgColor.a > 0) {
+                                                ctx.fillStyle = bgColor
+                                                ctx.beginPath()
+                                                
+                                                // 绘制右侧圆角的矩形
+                                                ctx.moveTo(0, 0)                           // 左上角
+                                                ctx.lineTo(width - 6, 0)                  // 右上角前
+                                                ctx.arcTo(width, 0, width, 6, 6)          // 右上圆角
+                                                ctx.lineTo(width, height - 6)             // 右下角前
+                                                ctx.arcTo(width, height, width - 6, height, 6) // 右下圆角
+                                                ctx.lineTo(0, height)                     // 左下角
+                                                ctx.lineTo(0, 0)                          // 回到左上角
+                                                
+                                                ctx.fill()
+                                            }
+                                        }
+                                        
+                                        onBgColorChanged: requestPaint()
                                     }
+                                    
+                                    // 分割线 - 一直显示
+                                    Rectangle {
+                                        width: 1
+                                        height: 20
+                                        anchors.left: parent.left
+                                        anchors.leftMargin: 0   // 在悬浮区域最左边
+                                        anchors.verticalCenter: parent.verticalCenter
+                                        color: palette.windowText
+                                        opacity: 0.05
+                                    }
+                                    
+                                    D.IconLabel {
+                                        anchors.centerIn: parent
+                                        icon {
+                                            name: "arrow_ordinary_right"
+                                            palette: D.DTK.makeIconPalette(palette)
+                                        }
+                                    }
+                                    
                                     MouseArea {
                                         anchors.fill: parent
+                                        hoverEnabled: true
                                         acceptedButtons: Qt.LeftButton
+                                        
                                         onClicked: {
                                             dccData.exec(NetManager.ConnectInfo, model.item.id, {})
+                                        }
+                                        
+                                        onEntered: {
+                                            hoverCanvas.bgColor = Qt.rgba(palette.windowText.r, palette.windowText.g, palette.windowText.b, 0.1)
+                                        }
+                                        
+                                        onExited: {
+                                            hoverCanvas.bgColor = "transparent"
+                                        }
+                                        
+                                        onPressed: {
+                                            hoverCanvas.bgColor = Qt.rgba(palette.windowText.r, palette.windowText.g, palette.windowText.b, 0.2)
+                                        }
+                                        
+                                        onReleased: {
+                                            if (containsMouse) {
+                                                hoverCanvas.bgColor = Qt.rgba(palette.windowText.r, palette.windowText.g, palette.windowText.b, 0.1)
+                                            } else {
+                                                hoverCanvas.bgColor = "transparent"
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
enhance network device list item UI

1. Replaced implicitHeight with explicit height for better control
2. Added hover effects with rounded corners for the arrow button
3. Improved padding and spacing for better visual alignment
4. Added visual feedback for mouse interactions (hover/press states)
5. Added a subtle divider line next to the arrow button
6. Made consistent changes to both wired and wireless device pages
7. Optimized icon sizing and positioning

The changes improve the visual hierarchy and interaction feedback in the network device list, making it more intuitive and polished. The hover effects provide clear affordances for interactive elements.

feat: 增强网络设备列表项UI

1. 使用显式高度替换隐式高度以获得更好控制
2. 为箭头按钮添加带圆角的悬停效果
3. 改进内边距和间距以获得更好的视觉对齐
4. 为鼠标交互添加视觉反馈(悬停/按下状态)
5. 在箭头按钮旁添加细分割线
6. 对有线和无线设备页面进行一致修改
7. 优化图标大小和定位

这些改动改善了网络设备列表的视觉层次和交互反馈，使其更加直观和精致。悬停
效果为交互元素提供了清晰的视觉提示。

pms: BUG-316565

## Summary by Sourcery

Improve visual hierarchy and interaction feedback of network device list items

Enhancements:
- Replace implicit list item height with explicit height and adjust padding, spacing, and icon sizing for consistent layout across wired and wireless device pages
- Add hover and press visual feedback to the arrow button with rounded-corner highlight, subtle divider line, and expanded interaction area