### PR TITLE
chore: update changelog for version 2.0.64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-network-core (2.0.64) unstable; urgency=medium
+
+  * Release 2.0.64
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 31 Jul 2025 19:44:25 +0800
+
 dde-network-core (2.0.63) unstable; urgency=medium
 
   * i18n: Updates for project Deepin Desktop Environment (#379)


### PR DESCRIPTION
1. Added new changelog entry for version 2.0.64
2. Included release date and maintainer information
3. Follows standard Debian changelog format
4. Maintains chronological order of releases

chore: 更新版本 2.0.64 的变更日志

1. 添加了版本 2.0.64 的新变更日志条目
2. 包含发布日期和维护者信息
3. 遵循标准的 Debian 变更日志格式
4. 保持版本发布的先后顺序

## Summary by Sourcery

Update the Debian changelog to include the new 2.0.64 release entry

Chores:
- Add changelog entry for version 2.0.64 with release date and maintainer information
- Ensure the entry follows the standard Debian changelog format and chronological order