### PR TITLE
chore: remove some translation markers for proper nouns

### DIFF
--- a/dcc-network-plugin/window/editpage/connectionvpneditpage.cpp
+++ b/dcc-network-plugin/window/editpage/connectionvpneditpage.cpp
@@ -91,12 +91,12 @@ void ConnectionVpnEditPage::initSettingsWidgetByType(ConnectionVpnEditPage::VpnT
         typeGrp->getLayout()->setContentsMargins(8, 0, 8, 0);
         typeGrp->appendItem(cbvpntype);
         QComboBox *comboBox = cbvpntype->comboBox();
-        comboBox->addItem(tr("L2TP"), VpnType::L2TP);
-        comboBox->addItem(tr("PPTP"), VpnType::PPTP);
-        comboBox->addItem(tr("OpenVPN"), VpnType::OPENVPN);
-        comboBox->addItem(tr("OpenConnect"), VpnType::OPENCONNECT);
-        comboBox->addItem(tr("StrongSwan"), VpnType::STRONGSWAN);
-        comboBox->addItem(tr("VPNC"), VpnType::VPNC);
+        comboBox->addItem("L2TP", VpnType::L2TP);
+        comboBox->addItem("PPTP", VpnType::PPTP);
+        comboBox->addItem("OpenVPN", VpnType::OPENVPN);
+        comboBox->addItem("OpenConnect", VpnType::OPENCONNECT);
+        comboBox->addItem("StrongSwan", VpnType::STRONGSWAN);
+        comboBox->addItem("VPNC", VpnType::VPNC);
 
         comboBox->setCurrentIndex(0);
 

--- a/dcc-network/qml/PageVPNSettings.qml
+++ b/dcc-network/qml/PageVPNSettings.qml
@@ -73,22 +73,22 @@ DccObject {
                 valueRole: "value"
                 currentIndex: indexOfValue(vpnType)
                 model: [{
-                        "text": qsTr("L2TP"),
+                        "text": "L2TP",
                         "value": NetUtils.VpnTypeEnum["l2tp"]
                     }, {
-                        "text": qsTr("PPTP"),
+                        "text": "PPTP",
                         "value": NetUtils.VpnTypeEnum["pptp"]
                     }, {
-                        "text": qsTr("OpenVPN"),
+                        "text": "OpenVPN",
                         "value": NetUtils.VpnTypeEnum["openvpn"]
                     }, {
-                        "text": qsTr("OpenConnect"),
+                        "text": "OpenConnect",
                         "value": NetUtils.VpnTypeEnum["openconnect"]
                     }, {
-                        "text": qsTr("StrongSwan"),
+                        "text": "StrongSwan",
                         "value": NetUtils.VpnTypeEnum["strongswan"]
                     }, {
-                        "text": qsTr("VPNC"),
+                        "text": "VPNC",
                         "value": NetUtils.VpnTypeEnum["vpnc"]
                     }]
                 onActivated: {

--- a/dcc-network/qml/SectionSecret.qml
+++ b/dcc-network/qml/SectionSecret.qml
@@ -233,15 +233,15 @@ DccTitleObject {
     ListModel {
         id: eapModelWired
         ListElement {
-            text: qsTr("TLS")
+            text: "TLS"
             value: "tls"
         }
         ListElement {
-            text: qsTr("MD5")
+            text: "MD5"
             value: "md5"
         }
         ListElement {
-            text: qsTr("FAST")
+            text: "FAST"
             value: "fast"
         }
         ListElement {
@@ -256,15 +256,15 @@ DccTitleObject {
     ListModel {
         id: eapModelWireless
         ListElement {
-            text: qsTr("TLS")
+            text: "TLS"
             value: "tls"
         }
         ListElement {
-            text: qsTr("LEAP")
+            text: "LEAP"
             value: "leap"
         }
         ListElement {
-            text: qsTr("FAST")
+            text: "FAST"
             value: "fast"
         }
         ListElement {
@@ -279,45 +279,45 @@ DccTitleObject {
     ListModel {
         id: fastAuthModel
         ListElement {
-            text: qsTr("GTC")
+            text: "GTC"
             value: "gtc"
         }
         ListElement {
-            text: qsTr("MSCHAPV2")
+            text: "MSCHAPV2"
             value: "mschapv2"
         }
     }
     ListModel {
         id: ttlsAuthModel
         ListElement {
-            text: qsTr("PAP")
+            text: "PAP"
             value: "pap"
         }
         ListElement {
-            text: qsTr("MSCHAP")
+            text: "MSCHAP"
             value: "mschap"
         }
         ListElement {
-            text: qsTr("MSCHAPV2")
+            text: "MSCHAPV2"
             value: "mschapv2"
         }
         ListElement {
-            text: qsTr("CHAP")
+            text: "CHAP"
             value: "chap"
         }
     }
     ListModel {
         id: peapAuthModel
         ListElement {
-            text: qsTr("GTC")
+            text: "GTC"
             value: "gtc"
         }
         ListElement {
-            text: qsTr("MD5")
+            text: "MD5"
             value: "md5"
         }
         ListElement {
-            text: qsTr("MSCHAPV2")
+            text: "MSCHAPV2"
             value: "mschapv2"
         }
     }

--- a/dcc-network/qml/SectionVPN.qml
+++ b/dcc-network/qml/SectionVPN.qml
@@ -1986,52 +1986,52 @@ DccTitleObject {
                         "text": qsTr("None"),
                         "value": "none"
                     }, {
-                        "text": qsTr("DES-CBC"),
+                        "text": "DES-CBC",
                         "value": "DES-CBC"
                     }, {
-                        "text": qsTr("RC2-CBC"),
+                        "text": "RC2-CBC",
                         "value": "RC2-CBC"
                     }, {
-                        "text": qsTr("DES-EDE-CBC"),
+                        "text": "DES-EDE-CBC",
                         "value": "DES-EDE-CBC"
                     }, {
-                        "text": qsTr("DES-EDE3-CBC"),
+                        "text": "DES-EDE3-CBC",
                         "value": "DES-EDE3-CBC"
                     }, {
-                        "text": qsTr("DESX-CBC"),
+                        "text": "DESX-CBC",
                         "value": "DESX-CBC"
                     }, {
-                        "text": qsTr("BF-CBC"),
+                        "text": "BF-CBC",
                         "value": "BF-CBC"
                     }, {
-                        "text": qsTr("RC2-40-CBC"),
+                        "text": "RC2-40-CBC",
                         "value": "RC2-40-CBC"
                     }, {
-                        "text": qsTr("CAST5-CBC"),
+                        "text": "CAST5-CBC",
                         "value": "CAST5-CBC"
                     }, {
-                        "text": qsTr("RC2-64-CBC"),
+                        "text": "RC2-64-CBC",
                         "value": "RC2-64-CBC"
                     }, {
-                        "text": qsTr("AES-128-CBC"),
+                        "text": "AES-128-CBC",
                         "value": "AES-128-CBC"
                     }, {
-                        "text": qsTr("AES-192-CBC"),
+                        "text": "AES-192-CBC",
                         "value": "AES-192-CBC"
                     }, {
-                        "text": qsTr("AES-256-CBC"),
+                        "text": "AES-256-CBC",
                         "value": "AES-256-CBC"
                     }, {
-                        "text": qsTr("CAMELLIA-128-CBC"),
+                        "text": "CAMELLIA-128-CBC",
                         "value": "CAMELLIA-128-CBC"
                     }, {
-                        "text": qsTr("CAMELLIA-192-CBC"),
+                        "text": "CAMELLIA-192-CBC",
                         "value": "CAMELLIA-192-CBC"
                     }, {
-                        "text": qsTr("CAMELLIA-256-CBC"),
+                        "text": "CAMELLIA-256-CBC",
                         "value": "CAMELLIA-256-CBC"
                     }, {
-                        "text": qsTr("SEED-CBC"),
+                        "text": "SEED-CBC",
                         "value": "SEED-CBC"
                     }]
                 onActivated: {
@@ -2125,10 +2125,10 @@ DccTitleObject {
                         "text": qsTr("Not Required"),
                         "value": "none"
                     }, {
-                        "text": qsTr("HTTP"),
+                        "text": "HTTP",
                         "value": "http"
                     }, {
-                        "text": qsTr("SOCKS"),
+                        "text": "SOCKS",
                         "value": "socks"
                     }]
                 onActivated: {


### PR DESCRIPTION
移除一些不可翻译的简写专有名词的翻译标注

## Summary by Sourcery

Remove translation wrappers from fixed acronym and protocol strings in VPN settings UI

Enhancements:
- Remove translation markers from cipher algorithm names in SectionVPN.qml
- Remove translation markers from HTTP and SOCKS protocol options
- Remove translation wrappers from EAP and authentication method names in SectionSecret.qml
- Remove translation markers from VPN type names in connectionvpneditpage.cpp and PageVPNSettings.qml