### PR TITLE
fix: improve icon rendering with theme support

### DIFF
--- a/net-view/window/private/neticonbutton.cpp
+++ b/net-view/window/private/neticonbutton.cpp
@@ -6,6 +6,9 @@
 #include <QMouseEvent>
 #include <QPainter>
 #include <QTimer>
+#include <QPaintDevice>
+#include <QPalette>
+#include <DGuiApplicationHelper>
 
 namespace dde {
 namespace network {
@@ -107,20 +110,20 @@ void NetIconButton::paintEvent(QPaintEvent *e)
         painter.translate(-(r.width() / 2), -(r.height() / 2));
     }
     const qreal scale = devicePixelRatio();
-    QSize pixmapSize = r.size() * scale;
-    QPixmap pm;
+    auto pa = palette();
+    if (Dtk::Gui::DGuiApplicationHelper::instance()->themeType() == Dtk::Gui::DGuiApplicationHelper::LightType) {
+        pa.setColor(QPalette::WindowText, Qt::black);
+    } else if (Dtk::Gui::DGuiApplicationHelper::instance()->themeType() == Dtk::Gui::DGuiApplicationHelper::DarkType) { 
+        pa.setColor(QPalette::WindowText, Qt::white);
+    }
+    // 设置dci图标单独调色板 参考dtk源码
+    // https://github.com/linuxdeepin/dtkgui/blob/9d3d659afedfa5813421e2430e26cd683246ab35/src/util/private/dciiconengine.cpp#L36C1-L37C1
+    setProperty("palette", pa);
     if (m_hover && !m_hoverIcon.isNull()) {
-        pm = m_hoverIcon.pixmap(pixmapSize);
+        m_hoverIcon.paint(&painter, r, Qt::AlignCenter);
     } else {
-        pm = m_icon.pixmap(pixmapSize);
+      m_icon.paint(&painter, r, Qt::AlignCenter);
     }
-    if (m_textType) {
-        QPainter pa(&pm);
-        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
-        pa.fillRect(pm.rect(), painter.pen().brush());
-    }
-    pm.setDevicePixelRatio(scale);
-    painter.drawPixmap(r, pm);
 }
 
 void NetIconButton::mousePressEvent(QMouseEvent *event)


### PR DESCRIPTION
1. Added DGuiApplicationHelper for theme detection
2. Implemented dynamic palette adjustment for light/dark themes
3. Simplified icon painting by removing intermediate pixmap creation
4. Removed text type handling as it's no longer needed
5. Added proper includes for QPaintDevice and QPalette

The changes improve icon rendering by:
- Supporting system theme changes (light/dark mode)
- Removing unnecessary pixmap conversions
- Following DTK's DCI icon rendering approach
- Making the code more maintainable by removing obsolete text handling

fix: 改进图标渲染并添加主题支持

1. 添加 DGuiApplicationHelper 用于主题检测
2. 实现动态调色板调整以支持浅色/深色主题
3. 通过移除中间位图创建简化图标绘制
4. 移除不再需要的文本类型处理
5. 添加 QPaintDevice 和 QPalette 的正确包含

这些改进通过以下方式优化了图标渲染：
- 支持系统主题变更（浅色/深色模式）
- 移除不必要的位图转换
- 遵循 DTK 的 DCI 图标渲染方法
- 通过移除过时的文本处理使代码更易维护

Pms: BUG-313753

## Summary by Sourcery

Add system theme support and simplify icon rendering by switching to direct painting and removing obsolete text handling.

New Features:
- Detect light/dark mode using DGuiApplicationHelper and adjust icon palette dynamically

Enhancements:
- Remove intermediate pixmap creation and use QIcon::paint for direct rendering
- Eliminate m_textType handling logic to streamline drawing
- Include necessary headers for QPaintDevice and QPalette