### PR TITLE
chore: bump version to 2.0.67

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-network-core (2.0.67) unstable; urgency=medium
+
+  * fix: allow empty IP list in manual mode and emit edit signals
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 21 Aug 2025 19:49:26 +0800
+
 dde-network-core (2.0.66) unstable; urgency=medium
 
   * fix: improve icon rendering with theme support


### PR DESCRIPTION
update changelog to 2.0.67

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 2.0.67