### PR TITLE
fix: update MTU configuration with valid range

### DIFF
--- a/dcc-network/qml/SectionDevice.qml
+++ b/dcc-network/qml/SectionDevice.qml
@@ -181,13 +181,16 @@ DccTitleObject {
             name: "mtu"
             parentName: root.parentName + "/devGroup"
             weight: 50
-            displayName: qsTr("MTU")
+            displayName: qsTr("MTU (1280-9000)")
             canSearch: false
             visible: hasMTU
             pageType: DccObject.Editor
             page: D.SpinBox {
                 editable: true
-                value: root.config.hasOwnProperty("mtu") ? root.config.mtu : 0
+                from: 1280
+                to: 9000
+                value: root.config.hasOwnProperty("mtu") ? root.config.mtu : 1500
+                
                 onValueChanged: {
                     if (hasMTU && (!root.config.hasOwnProperty("mtu") || root.config.mtu !== value)) {
                         root.config.mtu = value

--- a/dcc-network/qml/SectionVPN.qml
+++ b/dcc-network/qml/SectionVPN.qml
@@ -1646,7 +1646,7 @@ DccTitleObject {
         DccObject {
             name: "tunnel-mtu"
             parentName: root.parentName + "/vpnAdvancedGroup"
-            displayName: qsTr("MTU")
+            displayName: qsTr("MTU (1280-9000)")
             canSearch: false
             weight: 90
             visible: root.dataMap.hasOwnProperty("tunnel-mtu")
@@ -1654,8 +1654,8 @@ DccTitleObject {
             page: D.SpinBox {
                 editable: true
                 value: root.dataMap.hasOwnProperty(dccObj.name) ? parseInt(root.dataMap[dccObj.name], 10) : 1500
-                from: 0
-                to: 65535
+                from: 1280
+                to: 9000
                 onValueChanged: {
                     if (root.dataMap[dccObj.name] !== value) {
                         root.dataMap[dccObj.name] = value


### PR DESCRIPTION
Updated MTU configuration in both network device and VPN sections to enforce valid MTU range (1280-9000) and set appropriate default values. Changed display labels to include the valid range in parentheses for better user guidance. The MTU spin boxes now have proper minimum and maximum limits to prevent invalid values.

The changes ensure that users can only configure MTU values within the valid Ethernet MTU range (1280-9000 bytes) rather than the previous unlimited range. This prevents configuration errors and improves network stability by ensuring MTU values are within acceptable bounds. Default value changed from 0 to 1500 for network devices to match standard Ethernet MTU.

Log: Updated MTU configuration with valid range limits and improved labeling

Influence:
1. Test MTU configuration in network device settings with values within and outside the valid range
2. Verify VPN tunnel MTU configuration with boundary values (1280 and 9000)
3. Check that default values are properly set to 1500 when no previous configuration exists
4. Verify display labels show the valid range information
5. Test that invalid values cannot be entered through the spin box controls

feat: 更新MTU配置的有效范围

更新了网络设备和VPN部分的MTU配置，强制执行有效的MTU范围（1280-9000）并设
置适当的默认值。更改显示标签以在括号中包含有效范围，提供更好的用户指导。
MTU微调框现在具有适当的最小和最大限制，防止无效值。

这些更改确保用户只能在有效的以太网MTU范围（1280-9000字节）内配置MTU值，
而不是之前的无限制范围。这可以防止配置错误，并通过确保MTU值在可接受范围
内来提高网络稳定性。网络设备的默认值从0更改为1500以匹配标准以太网MTU。

Log: 更新了MTU配置的有效范围限制和改进的标签显示

Influence:
1. 测试网络设备设置中的MTU配置，使用有效范围内和范围外的值
2. 验证VPN隧道MTU配置的边界值（1280和9000）
3. 检查当不存在先前配置时，默认值是否正确设置为1500
4. 验证显示标签是否显示有效范围信息
5. 测试无法通过微调框控件输入无效值

PMS: BUG-331005

## Summary by Sourcery

Enforce valid MTU range across network device and VPN settings by restricting spin box limits, updating default values, and enhancing field labels.

Bug Fixes:
- Prevent invalid MTU values by enforcing a 1280–9000 byte range on spin boxes
- Update network device default MTU from 0 to 1500 to match standard Ethernet

Enhancements:
- Add valid range (1280-9000) to MTU field labels for improved user guidance