### PR TITLE
fix: prevent DNS assignment in disabled network modes

### DIFF
--- a/dcc-network/qml/PageSettings.qml
+++ b/dcc-network/qml/PageSettings.qml
@@ -224,9 +224,15 @@ DccObject {
                         }
                     }
                     
-                    // 分别保存到IPv4和IPv6配置中
-                    nConfig["ipv4"]["dns"] = ipv4Dns
-                    nConfig["ipv6"]["dns"] = ipv6Dns
+                    // 分别保存到IPv4和IPv6配置中，但要考虑各自的方法
+                    // 只有当IPv4不是disabled时才分配DNS
+                    if (nConfig["ipv4"]["method"] !== "disabled") {
+                        nConfig["ipv4"]["dns"] = ipv4Dns
+                    }
+                    // 只有当IPv6不是disabled和ignore时才分配DNS
+                    if (nConfig["ipv6"]["method"] !== "disabled" && nConfig["ipv6"]["method"] !== "ignore") {
+                        nConfig["ipv6"]["dns"] = ipv6Dns
+                    }
                     let devConfig = sectionDevice.getConfig()
                     if (devConfig.interfaceName.length === 0) {
                         delete nConfig["connection"]["interface-name"]

--- a/dcc-network/qml/SectionIPv4.qml
+++ b/dcc-network/qml/SectionIPv4.qml
@@ -51,6 +51,15 @@ DccObject {
         } else {
             delete sConfig["addresses"]
             delete sConfig["address-data"]
+            delete sConfig["gateway"]  // 非手动模式下不应保留手动设置的网关
+            
+            // 禁用模式下不应该有任何IPv4配置字段
+            if (method === "disabled") {
+                delete sConfig["dns"]
+                delete sConfig["dns-search"]
+                delete sConfig["ignore-auto-dns"]
+                delete sConfig["ignore-auto-routes"]
+            }
         }
 
         return sConfig

--- a/dcc-network/qml/SectionIPv6.qml
+++ b/dcc-network/qml/SectionIPv6.qml
@@ -42,8 +42,22 @@ DccObject {
     function getConfig() {
         let sConfig = root.config
         sConfig["method"] = method
-        sConfig["address-data"] = addressData
-        sConfig["gateway"] = gateway
+        if (method === "manual") {
+            sConfig["address-data"] = addressData
+            sConfig["gateway"] = gateway
+        } else {
+            delete sConfig["address-data"]
+            delete sConfig["gateway"]
+            delete sConfig["addresses"]
+            
+            // 禁用和忽略模式下不应该有任何IPv6配置字段
+            if (method === "disabled" || method === "ignore") {
+                delete sConfig["dns"]
+                delete sConfig["dns-search"]
+                delete sConfig["ignore-auto-dns"]
+                delete sConfig["ignore-auto-routes"]
+            }
+        }
         return sConfig
     }
     function checkInput() {

--- a/net-view/operation/private/netmanagerthreadprivate.cpp
+++ b/net-view/operation/private/netmanagerthreadprivate.cpp
@@ -1578,7 +1578,9 @@ void NetManagerThreadPrivate::doSetConnectInfo(const QString &id, NetType::NetIt
     } else {
         // 更新
         connection = findConnectionByUuid(settings->uuid());
-        QDBusPendingReply<> reply = connection->isUnsaved() ? connection->updateUnsaved(settings->toMap()) : connection->update(settings->toMap());
+        NMVariantMapMap finalSettings = settings->toMap();
+
+        QDBusPendingReply<> reply = connection->isUnsaved() ? connection->updateUnsaved(finalSettings) : connection->update(finalSettings);
         reply.waitForFinished();
         if (reply.isError()) {
             qCWarning(DNC) << "Error occurred while updating the connection, error: " << reply.error();


### PR DESCRIPTION
Fixed an issue where DNS settings were incorrectly being saved for IPv4 and IPv6 when their respective methods were set to disabled or ignore modes. Added conditional checks to only assign DNS configurations when the network method is active. Also cleaned up configuration fields that should not persist in disabled modes to ensure proper network configuration.

The changes include:
1. Added condition checks before assigning DNS to IPv4 and IPv6 configurations
2. Removed unnecessary configuration fields (gateway, dns, dns-search, etc.) when methods are disabled
3. Ensured consistent behavior across both IPv4 and IPv6 configuration sections
4. Maintained proper configuration cleanup to prevent invalid settings

Influence:
1. Test network configuration with IPv4 disabled mode - verify no DNS settings are saved
2. Test IPv6 disabled and ignore modes - verify no DNS or other unnecessary fields persist
3. Verify manual mode still correctly saves all configuration fields
4. Test automatic modes to ensure proper DNS assignment behavior
5. Validate network connectivity after configuration changes

fix: 修复禁用网络模式下DNS设置错误保存的问题

修复了当IPv4和IPv6方法设置为禁用或忽略模式时，DNS设置仍被错误保存的问
题。添加了条件检查，仅在网络方法处于活动状态时才分配DNS配置。同时清理了
在禁用模式下不应保留的配置字段，确保网络配置的正确性。

更改包括：
1. 在分配DNS到IPv4和IPv6配置前添加条件检查
2. 当方法被禁用时移除不必要的配置字段（网关、DNS、DNS搜索等）
3. 确保IPv4和IPv6配置部分行为一致
4. 保持正确的配置清理以防止无效设置

Influence:
1. 测试IPv4禁用模式下的网络配置 - 验证DNS设置未被保存
2. 测试IPv6禁用和忽略模式 - 验证DNS和其他不必要字段未保留
3. 验证手动模式仍正确保存所有配置字段
4. 测试自动模式以确保正确的DNS分配行为
5. 验证配置更改后的网络连接性

PMS: BUG-331017

## Summary by Sourcery

Prevent DNS and other manual-only configuration fields from being saved when IPv4 or IPv6 network methods are disabled or ignored, and ensure consistent cleanup of configuration fields in these modes.

Bug Fixes:
- Only assign IPv4 DNS settings when its method is not disabled
- Only assign IPv6 DNS settings when its method is neither disabled nor ignored
- Remove manual-only fields (address-data, gateway, addresses) when method is not manual
- Remove DNS and related fields (dns-search, ignore-auto-dns, ignore-auto-routes) in disabled/ignore modes for both IPv4 and IPv6

Enhancements:
- Refactor doSetConnectInfo to reuse a single settings map for connection updates