### PR TITLE
fix: adjust dock network widget height calculation

### DIFF
--- a/dock-network-plugin/dockcontentwidget.h
+++ b/dock-network-plugin/dockcontentwidget.h
@@ -89,7 +89,7 @@ public Q_SLOTS:
         m_netView->setMaxHeight(h);
         if (m_netView->height() > h)
             m_netView->setFixedHeight(h);
-        setFixedSize(m_netView->width(), qMax(m_minHeight, m_netView->height() + 20 + m_mainLayout->contentsMargins().top() + (m_netCheckBtn->isVisibleTo(this) ? (m_netSetBtn->height() + m_netCheckBtn->height() + 10) : m_netSetBtn->height())));
+        setFixedSize(m_netView->width(), qMax(m_minHeight, m_netView->height() + 20 + m_mainLayout->contentsMargins().top() + (m_netCheckBtn->isVisibleTo(this) ? (m_netSetBtn->height() + m_netCheckBtn->height() + 10) : m_netSetBtn->height()) + 20));
     }
     void setNetCheckBtnVisible(bool visible) {
         m_netCheckBtn->setVisible(visible);


### PR DESCRIPTION
The height calculation for the dock network widget was incorrect, causing the widget to be too short when the network check button is visible. The issue was that the calculation didn't include enough padding at the bottom of the widget, resulting in UI elements being cut off or too close to the edge.

The fix adds an extra 20 pixels to the total height calculation when setting the fixed size. This ensures proper spacing between the network view content and the bottom of the widget container, especially when the network check button is displayed.

Log: Fixed dock network panel height issue where content was too close to bottom edge

Influence:
1. Test dock network widget display with network check button visible
2. Verify widget height is sufficient to show all content without clipping
3. Check spacing between network view and widget boundaries
4. Test both scenarios: with and without network check button visible
5. Verify overall dock panel layout remains consistent

fix: 调整任务栏网络插件高度计算

任务栏网络插件的高度计算存在错误，导致网络检查按钮可见时插件高度过小。问
题在于计算底部填充不足，导致UI元素被截断或过于靠近边缘。

修复方法是在设置固定大小时，在总高度计算中添加额外的20像素。这确保了网络
视图内容与插件容器底部之间有适当的间距，特别是在网络检查按钮显示时。

Log: 修复了任务栏网络面板高度问题，解决了内容过于靠近底部边缘的情况

Influence:
1. 测试网络检查按钮可见时的任务栏网络插件显示
2. 验证插件高度是否足够显示所有内容而不被裁剪
3. 检查网络视图与插件边界之间的间距
4. 测试两种场景：网络检查按钮可见和不可见
5. 验证整体任务栏面板布局保持一致性

PMS: BUG-353585