### PR TITLE
perf: optimize dock network plugin panel height resizing frequency

### DIFF
--- a/dock-network-plugin/dockcontentwidget.h
+++ b/dock-network-plugin/dockcontentwidget.h
@@ -18,6 +18,7 @@
 #include <QTreeView>
 #include <QVBoxLayout>
 #include <QWidget>
+#include <QTimer>
 
 namespace dde {
 namespace network {
@@ -31,7 +32,12 @@ public:
         , m_mainLayout(new QVBoxLayout(this))
         , m_netView(netView)
         , m_minHeight(-1)
+        , m_updateTimer(new QTimer(this))
     {
+        m_updateTimer->setSingleShot(true);
+        m_updateTimer->setInterval(150);
+        connect(m_updateTimer, &QTimer::timeout, this, &DockContentWidget::doUpdateSize);
+
         m_netView->installEventFilter(this);
         m_netView->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
         connect(m_netView, &NetView::updateSize, this, &DockContentWidget::updateSize);
@@ -71,6 +77,14 @@ public:
 
 public Q_SLOTS:
     void updateSize() {
+        if (!isVisible()) {
+            doUpdateSize();
+        } else {
+            m_updateTimer->start();
+        }
+    }
+
+    void doUpdateSize() {
         auto h = Dock::DOCK_POPUP_WIDGET_MAX_HEIGHT - 20 - m_mainLayout->contentsMargins().top() - (m_netCheckBtn->isVisible() ? (m_netSetBtn->height() + m_netCheckBtn->height() + 10) : m_netSetBtn->height());
         m_netView->setMaxHeight(h);
         if (m_netView->height() > h)
@@ -93,10 +107,10 @@ protected:
 
     void showEvent(QShowEvent *event) override
     {
-        updateSize();
+        doUpdateSize();
         QWidget::showEvent(event);
         QMetaObject::invokeMethod(this, [this]() {
-            updateSize();
+            doUpdateSize();
             resize(size());
         }, Qt::QueuedConnection);
     }
@@ -115,6 +129,7 @@ private:
     int m_minHeight;
     JumpSettingButton *m_netSetBtn;
     JumpSettingButton *m_netCheckBtn;
+    QTimer *m_updateTimer;
 };
 
 } // namespace network


### PR DESCRIPTION
Introduced a QTimer to debounce the updateSize calls within the DockContentWidget. This heavily reduces the number of layout and geometry calculation events fired to the compositor (max 1 per 150ms) when rapidly scanning and appending Wi-Fi hotspots, thereby fixing visual flickering issues in Wayland without leaving dead space.

性能：优化任务栏网络插件面板高度调整频率

在 DockContentWidget 内部引入了 QTimer 对 updateSize 调用进行节流 （防抖）处理。扫描并连续追加 Wi-Fi 热点时，大幅减少发往合成器的
布局与几何计算事件（受限于最多 150ms 一次），从而修复了 Wayland 下
因窗口频繁变尺寸而引发的闪烁问题，同时也完整保留了正常的自适应包
裹尺寸机制。

Log: optimize dock network plugin panel height resizing frequency

## Summary by Sourcery

Enhancements:
- Limit dock network panel height recalculation frequency via a timer-driven size update to avoid excessive geometry updates while preserving adaptive sizing behavior.