### PR TITLE
fix: fix incomplete display

### DIFF
--- a/dock-network-plugin/dockcontentwidget.h
+++ b/dock-network-plugin/dockcontentwidget.h
@@ -55,9 +55,8 @@ public:
         buttonWidget->setLayout(buttonLayout);
 
         m_mainLayout->setContentsMargins(0, 10, 0, 0);
+        m_mainLayout->setSpacing(0);
         m_mainLayout->addWidget(m_netView, 0, Qt::AlignTop | Qt::AlignHCenter);
-        m_mainLayout->addStretch();
-        m_mainLayout->addSpacing(10);
         m_mainLayout->addWidget(buttonWidget, 0, Qt::AlignBottom);
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
         setMaximumHeight(Dock::DOCK_POPUP_WIDGET_MAX_HEIGHT);

--- a/dock-network-plugin/networkplugin.cpp
+++ b/dock-network-plugin/networkplugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -385,12 +385,6 @@ QString NetworkPlugin::message(const QString &msg)
     }
 
     const auto &msgObj = resultDoc.object();
-    if (msgObj.value(Dock::MSG_TYPE).toString() == Dock::MSG_SET_APPLET_MIN_HEIGHT) {
-        const int minHeight = msgObj.value(Dock::MSG_DATA).toInt(-1);
-        if (m_dockContentWidget && minHeight > 0)
-            m_dockContentWidget->setMinHeight(minHeight);
-    }
-
     if (msgObj.value(Dock::MSG_TYPE).toString() == Dock::MSG_APPLET_CONTAINER && m_dockContentWidget) {
         m_dockContentWidget->setMainLayoutMargins(QMargins(0, msgObj.value(Dock::MSG_DATA).toInt(-1) ==
             Dock::APPLET_CONTAINER_QUICK_PANEL ? 6 : 10, 0, 0));


### PR DESCRIPTION
there is extra spacing in the layout, causing display issues.

Log: fix incomplete display
PMS: BUG-353585

fix: 修复显示不全

布局中多了间距，显示有问题

Log: 修复显示不全

## Summary by Sourcery

Adjust the network dock applet layout to remove unintended spacing and rely on a fixed layout configuration instead of dynamic minimum height updates.

Bug Fixes:
- Eliminate extra vertical spacing in the network dock popup to ensure the content is fully visible.

Enhancements:
- Simplify dock content layout by removing dynamic minimum height handling and enforcing zero spacing between main layout elements.