### PR TITLE
chore: update changelog to 2.0.88

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+dde-network-core (2.0.88) unstable; urgency=medium
+
+  * perf: optimize dock network plugin panel height resizing frequency
+  * fix: fix incomplete display there is extra spacing in the layout,
+    causing display issues.
+  * Fix: Network panel input field in the taskbar is not within the
+    visible area.
+  * style(hotspot): optimize hotspot dialog UI appearance
+  * fix: fix the language of the first connection which create
+  * fix: fix null pointer and improve DNS/IP configuration
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 09 Apr 2026 20:27:59 +0800
+
 dde-network-core (2.0.87) unstable; urgency=medium
 
   * chore: update the translations


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.88

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.88
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump recorded package version to 2.0.88 in debian/changelog.