### PR TITLE
fix: remove minHeight reset and add minHeight message handling

### DIFF
--- a/dock-network-plugin/dockcontentwidget.h
+++ b/dock-network-plugin/dockcontentwidget.h
@@ -118,7 +118,6 @@ protected:
     void hideEvent(QHideEvent *event) override
     {
         QWidget::hideEvent(event);
-        m_minHeight = -1;
         // 隐藏时更新尺寸为折叠状态，确保下次显示时初始尺寸正确
         QMetaObject::invokeMethod(this, "updateSize", Qt::QueuedConnection);
     }

--- a/dock-network-plugin/networkplugin.cpp
+++ b/dock-network-plugin/networkplugin.cpp
@@ -385,6 +385,13 @@ QString NetworkPlugin::message(const QString &msg)
     }
 
     const auto &msgObj = resultDoc.object();
+
+    if (msgObj.value(Dock::MSG_TYPE).toString() == Dock::MSG_SET_APPLET_MIN_HEIGHT) {
+        const int minHeight = msgObj.value(Dock::MSG_DATA).toInt(-1);
+        if (m_dockContentWidget && minHeight > 0)
+            m_dockContentWidget->setMinHeight(minHeight);
+    }
+
     if (msgObj.value(Dock::MSG_TYPE).toString() == Dock::MSG_APPLET_CONTAINER && m_dockContentWidget) {
         m_dockContentWidget->setMainLayoutMargins(QMargins(0, msgObj.value(Dock::MSG_DATA).toInt(-1) ==
             Dock::APPLET_CONTAINER_QUICK_PANEL ? 6 : 10, 0, 0));


### PR DESCRIPTION
1. Removed m_minHeight reset in hideEvent to preserve minimum height setting across hide/show cycles
2. Added message handling for MSG_SET_APPLET_MIN_HEIGHT to support dynamic minimum height configuration
3. The plugin now responds to external requests to set minimum height for the applet container
4. This ensures proper layout behavior when the dock content widget is hidden and shown again

Log: Fixed dock network plugin layout preservation issues

Influence:
1. Test hiding and showing the network plugin in dock to verify height preservation
2. Verify that external messages to set minimum height are properly processed
3. Test with different minimum height values to ensure correct layout behavior
4. Check that the plugin maintains consistent appearance after multiple hide/show cycles
5. Verify compatibility with dock container margin settings

fix: 移除最小高度重置并添加最小高度消息处理

1. 移除 hideEvent 中的 m_minHeight 重置，以在隐藏/显示周期中保持最小高度 设置
2. 添加 MSG_SET_APPLET_MIN_HEIGHT 消息处理，支持动态最小高度配置
3. 插件现在能够响应外部设置应用容器最小高度的请求
4. 确保停靠栏内容部件在隐藏和再次显示时具有正确的布局行为

Log: 修复停靠栏网络插件布局保持问题

Influence:
1. 测试隐藏和显示停靠栏中的网络插件，验证高度保持功能
2. 验证外部设置最小高度的消息是否被正确处理
3. 使用不同的最小高度值测试，确保正确的布局行为
4. 检查插件在多次隐藏/显示循环后是否保持一致的显示效果
5. 验证与停靠栏容器边距设置的兼容性

PMS: BUG-356951

## Summary by Sourcery

Preserve the dock network plugin applet's minimum height across hide/show cycles and handle external messages to update it dynamically.

Bug Fixes:
- Fix loss of the applet's configured minimum height when the dock network plugin is hidden and shown again.

Enhancements:
- Add support for processing external messages to set the applet container's minimum height, ensuring correct layout behavior with varying dock margins.