### PR TITLE
chore: update changelog to 2.0.89

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-network-core (2.0.89) unstable; urgency=medium
+
+  * fix: remove minHeight reset and add minHeight message handling
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 23 Apr 2026 21:46:50 +0800
+
 dde-network-core (2.0.88) unstable; urgency=medium
 
   * perf: optimize dock network plugin panel height resizing frequency


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.89

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.89
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump recorded package version to 2.0.89 in debian/changelog.