### PR TITLE
fix: set alert duration to 2000ms and show error text

### DIFF
--- a/dcc-network/qml/SectionIPv4.qml
+++ b/dcc-network/qml/SectionIPv4.qml
@@ -384,7 +384,8 @@ DccObject {
                             }
                         }
                         showAlert: errorKey === index + dccObj.name
-                        alertDuration: 1
+                        alertDuration: 2000
+                        alertText: errorKey === index + dccObj.name ? root.errorMsg : ""
                         onShowAlertChanged: {
                             if (showAlert) {
                                 DccApp.showPage(dccObj)


### PR DESCRIPTION
1. Change showAlert duration from 1ms to 2000ms to ensure the alert is visible to the user
2. Display the actual error message text in the alert tooltip instead of leaving it empty

Log: Fix IPv4 section alert not visible due to too short duration and missing error text

fix: 设置告警显示时长为2000ms并展示错误文本

1. 将 showAlert 时长从 1ms 改为 2000ms，确保告警能被用户看到
2. 在告警提示中显示实际的错误信息文本

Log: 修复 IPv4 区域告警因时长过短且缺少错误文本而不可见的问题
PMS: TASK-389903