### PR TITLE
fix: disconnect D-Bus system bus connections in destructor before thread exit

### DIFF
--- a/net-view/operation/private/netmanagerthreadprivate.cpp
+++ b/net-view/operation/private/netmanagerthreadprivate.cpp
@@ -109,6 +109,27 @@ NetManagerThreadPrivate::~NetManagerThreadPrivate()
 {
     // 先断开所有信号，防止析构期间再有新任务（如singleShot）入队
     disconnect();
+
+    // 断开 doInit() 中注册的 D-Bus 系统总线连接
+    // 必须在 m_thread->quit() 之前执行，否则 QDBusConnectionManager 线程
+    // 在全局清理时会访问已释放的工作线程对象，导致 use-after-free 崩溃
+    QDBusConnection::systemBus().disconnect("com.deepin.defender.netcheck", "/com/deepin/defender/netcheck", "org.freedesktop.DBus.Properties", "PropertiesChanged", this, SLOT(onNetCheckPropertiesChanged(QString, QVariantMap, QStringList)));
+    QDBusConnection::systemBus().disconnect("org.freedesktop.login1", "/org/freedesktop/login1", "org.freedesktop.login1.Manager", "PrepareForSleep", this, SLOT(onPrepareForSleep(bool)));
+    if (ConfigSetting::instance()->supportPortalPromp()) {
+        QDBusConnection::systemBus().disconnect("org.deepin.dde.Network1",
+                                                "/org/deepin/service/SystemNetwork",
+                                                "org.deepin.service.SystemNetwork",
+                                                "PortalDetected",
+                                                this,
+                                                SLOT(onPortalDetected(const QString &)));
+    }
+    
+    if (m_flags.testFlags(NetType::NetManagerFlag::Net_Airplane)) {
+        QDBusConnection::systemBus().disconnect("org.deepin.dde.Bluetooth1", "/org/deepin/dde/Bluetooth1", "org.deepin.dde.Bluetooth1", "AdapterAdded", this, SLOT(getAirplaneModeEnabled()));
+        QDBusConnection::systemBus().disconnect("org.deepin.dde.Bluetooth1", "/org/deepin/dde/Bluetooth1", "org.deepin.dde.Bluetooth1", "AdapterRemoved", this, SLOT(getAirplaneModeEnabled()));
+        QDBusConnection::systemBus().disconnect("org.deepin.dde.AirplaneMode1", "/org/deepin/dde/AirplaneMode1", "org.freedesktop.DBus.Properties", "PropertiesChanged", this, SLOT(onAirplaneModeEnabledPropertiesChanged(QString, QVariantMap, QStringList)));
+    }
+
     m_thread->quit();
     // 增大等待时间至1000ms，避免50ms定时器回调等正在执行的任务被terminate强杀
     m_thread->wait(QDeadlineTimer(1000));


### PR DESCRIPTION
Disconnect all QDBusConnection::systemBus() signals registered in doInit() from the worker thread before quitting m_thread. This prevents a use-after-free crash in QDBusConnectionManager during application exit when it tries to close qt_default_system_bus and accesses already-freed worker-thread objects.

Log: Fix dcc-network plugin crash on exit due to D-Bus connection leak

fix: 在析构函数中断开D-Bus系统总线连接，避免线程退出后崩溃

在退出工作线程(m_thread)之前，断开doInit()中注册的所有QDBusConnection::systemBus()信号连接。防止应用退出时QDBusConnectionManager清理qt_default_system_bus时访问已释放的工作线程对象导致use-after-free崩溃。

Log: 修复dcc-network插件退出时因D-Bus连接未清理导致的崩溃
PMS: BUG-363425

## Summary by Sourcery

Bug Fixes:
- Prevent a use-after-free crash on application exit by disconnecting QDBusConnection::systemBus() signals registered in the worker thread before quitting the thread.