### PR TITLE
fix: add per-device internet connectivity check for network switching

### DIFF
--- a/config/org.deepin.dde.network.json
+++ b/config/org.deepin.dde.network.json
@@ -338,6 +338,17 @@
             "description":"the span to check connectivity(unit:second) when limit",
             "permissions":"readwrite",
             "visibility":"private"
+         },
+         "needCheckNetwork":{
+            "value":true,
+            "serial":0,
+            "flags":["global"],
+            "name":"needCheckNetwork",
+            "name[zh_CN]":"是否检测网络可用性并切换网络",
+            "description[zh_CN]":"是否检测网络可用性并切换网络",
+            "description":"if check the network is unavailable and then switch to the available network",
+            "permissions":"readwrite",
+            "visibility":"private"
          }
     }
 }

--- a/network-service-plugin/src/system/connectivitychecker.cpp
+++ b/network-service-plugin/src/system/connectivitychecker.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "connectivitychecker.h"
+#include "internetchecker.h"
 
 #include "settingconfig.h"
 #include "httpmanager.h"
@@ -27,12 +28,22 @@ LocalConnectionvityChecker::LocalConnectionvityChecker(QObject *parent)
     , m_statusChecker(new StatusChecker)
     , m_connectivity(network::service::Connectivity::Unknownconnectivity)
     , m_thread(new QThread)
+    , m_internetCheckerThread(nullptr)
+    , m_internetChecker(nullptr)
 {
     m_statusChecker->moveToThread(m_thread);
     connect(m_statusChecker, &StatusChecker::portalDetected, this, &LocalConnectionvityChecker::onPortalDetected);
     connect(m_statusChecker, &StatusChecker::connectivityChanged, this, &LocalConnectionvityChecker::onConnectivityChanged);
     m_thread->start();
     QMetaObject::invokeMethod(m_statusChecker, &StatusChecker::initConnectivityChecker, Qt::QueuedConnection);
+    if (SettingConfig::instance()->needCheckNetwork()) {
+        m_internetCheckerThread = new QThread(this);
+        m_internetChecker = new InternetChecker;
+        m_internetChecker->moveToThread(m_internetCheckerThread);
+        m_internetCheckerThread->start();
+        connect(m_internetChecker, &InternetChecker::switchSuccess, m_statusChecker, &StatusChecker::checkConnectivity);
+        connect(m_internetCheckerThread, &QThread::finished, m_internetChecker, &QObject::deleteLater);
+    }
 }
 
 LocalConnectionvityChecker::~LocalConnectionvityChecker()
@@ -42,6 +53,11 @@ LocalConnectionvityChecker::~LocalConnectionvityChecker()
     m_thread->wait();
     m_statusChecker->deleteLater();
     m_thread->deleteLater();
+    if (m_internetCheckerThread) {
+        m_internetCheckerThread->quit();
+        m_internetCheckerThread->wait();
+        m_internetCheckerThread->deleteLater();
+    }
 }
 
 network::service::Connectivity LocalConnectionvityChecker::connectivity() const
@@ -75,6 +91,12 @@ void LocalConnectionvityChecker::onPortalDetected(const QString &portalUrl)
 
 void LocalConnectionvityChecker::onConnectivityChanged(network::service::Connectivity connectivity)
 {
+    if (m_internetChecker && (connectivity == network::service::Connectivity::Limited
+                              || connectivity == network::service::Connectivity::Noconnectivity
+                              || connectivity == network::service::Connectivity::Unknownconnectivity)) {
+        // 在开启网络检测的情况下，如果当前网络不可用，则启动切换主连接的工作流程，尝试恢复网络连通性。
+        QMetaObject::invokeMethod(m_internetChecker, &InternetChecker::switchInternetAccess, Qt::QueuedConnection);
+    }
     qCInfo(DSM) << "Connectivity changed, incomming: " << static_cast<int>(connectivity) << ", current: " << static_cast<int>(m_connectivity);
     if (m_connectivity == connectivity)
         return;

--- a/network-service-plugin/src/system/connectivitychecker.h
+++ b/network-service-plugin/src/system/connectivitychecker.h
@@ -20,6 +20,7 @@ namespace network {
 namespace systemservice {
 
 class StatusChecker;
+class InternetChecker;
 
 // 网络连通性的检测
 class ConnectivityChecker : public QObject
@@ -64,6 +65,8 @@ private:
     QString m_portalUrl;
     network::service::Connectivity m_connectivity;
     QThread *m_thread;
+    QThread *m_internetCheckerThread;
+    InternetChecker *m_internetChecker;
 };
 
 class StatusChecker : public QObject

--- a/network-service-plugin/src/system/internetchecker.cpp
+++ b/network-service-plugin/src/system/internetchecker.cpp
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "internetchecker.h"
+
+#include "httpmanager.h"
+#include "settingconfig.h"
+#include "constants.h"
+
+#include <QDebug>
+#include <QTimer>
+#include <QThread>
+#include <QElapsedTimer>
+
+#include <NetworkManagerQt/Manager>
+#include <NetworkManagerQt/ActiveConnection>
+#include <NetworkManagerQt/Ipv4Setting>
+#include <NetworkManagerQt/Ipv6Setting>
+#include <NetworkManagerQt/Settings>
+
+using namespace network::systemservice;
+
+InternetChecker::InternetChecker(QObject *parent)
+    : QObject(parent)
+    , m_tryIndex(0)
+    , m_switchTimer(nullptr)
+    , m_isSwitching(false)
+{
+    connect(NetworkManager::notifier(), &NetworkManager::Notifier::primaryConnectionChanged,
+            this, &InternetChecker::onPrimaryConnectionChanged);
+}
+
+InternetChecker::~InternetChecker()
+{
+    if (m_switchTimer) {
+        m_switchTimer->stop();
+        m_switchTimer->deleteLater();
+    }
+}
+
+void InternetChecker::resetAllNeverDefault() const
+{
+    const NetworkManager::Device::List devices = NetworkManager::networkInterfaces();
+    for (const NetworkManager::Device::Ptr &device : devices) {
+        NetworkManager::ActiveConnection::Ptr activeConn = device->activeConnection();
+        if (!activeConn.isNull())
+            setConnectionNeverDefault(activeConn->connection(), device, false);
+    }
+}
+
+bool InternetChecker::setConnectionNeverDefault(const NetworkManager::Connection::Ptr &conn,
+                                               const NetworkManager::Device::Ptr &device,
+                                               bool neverDefault) const
+{
+    if (conn.isNull())
+        return false;
+
+    NMVariantMapMap settingsMap;
+    bool changed = false;
+
+    NetworkManager::Setting::Ptr ipv4Setting = conn->settings()->setting(NetworkManager::Setting::Ipv4);
+    if (ipv4Setting) {
+        NetworkManager::Ipv4Setting::Ptr ipv4 = ipv4Setting.dynamicCast<NetworkManager::Ipv4Setting>();
+        if (ipv4->neverDefault() != neverDefault) {
+            ipv4->setNeverDefault(neverDefault);
+            settingsMap.insert(ipv4->name(), ipv4->toMap());
+            changed = true;
+        }
+    }
+    NetworkManager::Setting::Ptr ipv6Setting = conn->settings()->setting(NetworkManager::Setting::Ipv6);
+    if (ipv6Setting) {
+        NetworkManager::Ipv6Setting::Ptr ipv6 = ipv6Setting.dynamicCast<NetworkManager::Ipv6Setting>();
+        if (ipv6->neverDefault() != neverDefault) {
+            ipv6->setNeverDefault(neverDefault);
+            settingsMap.insert(ipv6->name(), ipv6->toMap());
+            changed = true;
+        }
+    }
+    if (changed) {
+        conn->updateUnsaved(settingsMap);
+        if (!device.isNull())
+            device->reapplyConnection(conn->settings()->toMap(), 0, 0);
+        qCInfo(DSM) << "Set connection" << conn->name() << "never-default to" << neverDefault;
+    }
+    return changed;
+}
+
+void InternetChecker::setPrimaryDeviceNeverDefault(bool neverDefault) const
+{
+    NetworkManager::ActiveConnection::Ptr primaryConn = NetworkManager::primaryConnection();
+    if (primaryConn.isNull())
+        return;
+
+    const QStringList deviceUnis = primaryConn->devices();
+    for (const QString &uni : deviceUnis) {
+        NetworkManager::Device::Ptr device = NetworkManager::findNetworkInterface(uni);
+        if (!device.isNull())
+            changeDeviceNeverDefault(device, neverDefault);
+    }
+}
+
+bool InternetChecker::checkInternetAccessible() const
+{
+    bool timedOut = false;
+    return checkInternetAccessible(0, timedOut);
+}
+
+bool InternetChecker::checkInternetAccessible(int timeoutSec, bool &timedOut) const
+{
+    timedOut = false;
+
+    const QStringList checkUrls = SettingConfig::instance()->networkCheckerUrls();
+    for (const QString &url : checkUrls) {
+        network::service::HttpManager http;
+        network::service::HttpReply *httpReply = (timeoutSec > 0)
+                ? http.get(url, timeoutSec)
+                : http.get(url);
+        if (httpReply->httpCode() != 0) {
+            return true;
+        }
+        if (httpReply->isTimeout()) {
+            timedOut = true;
+            break;
+        }
+    }
+    return false;
+}
+
+bool InternetChecker::checkInternetAccessibleWithRetry(int maxRetry) const
+{
+    for (int i = 0; i < maxRetry; ++i) {
+        // 每次检测前等待1秒，让NM路由表和DHCP先稳定
+        QThread::sleep(1);
+        bool timedOut = false;
+        // 首次使用20秒超时，避免在无网线路由器的环境中长时间阻塞
+        QElapsedTimer timer;
+        timer.start();
+        if (checkInternetAccessible((i == 0) ? 20 : 0, timedOut)) {
+            return true;
+        }
+        if (timedOut) {
+            qCDebug(DSM) << "Request timed out after" << timer.elapsed() << "ms, skipping retries";
+            return false;
+        }
+    }
+    return false;
+}
+
+void InternetChecker::changeDeviceNeverDefault(const NetworkManager::Device::Ptr &device, bool neverDefault) const
+{
+    if (device.isNull())
+        return;
+
+    NetworkManager::ActiveConnection::Ptr activeConn = device->activeConnection();
+    if (activeConn.isNull())
+        return;
+
+    NetworkManager::Connection::Ptr conn = activeConn->connection();
+    setConnectionNeverDefault(conn, device, neverDefault);
+}
+
+void InternetChecker::onPrimaryConnectionChanged(const QString &uni)
+{
+    Q_UNUSED(uni)
+
+    // 停止超时定时器
+    if (m_switchTimer) {
+        m_switchTimer->stop();
+    }
+
+    qCInfo(DSM) << "Primary connection changed:" << uni;
+    // NM已切换主连接，通过默认路由检测整体是否可以上网（重试3次，等待DHCP/路由生效）
+    if (checkInternetAccessibleWithRetry(3)) {
+        qCInfo(DSM) << "Found accessible device, switching done";
+        // 当前主设备已经是能上网的，它的never-default本来就是false，无需额外操作
+        // 此处不能恢复其他设备never default, 因为如果恢复后，NM 内部会根据每个设备的metric值又将主链接设置回去了，导致无法上网
+        m_tryIndex = 0;
+        m_isSwitching = false;
+        emit switchSuccess();
+    } else if (m_tryIndex < m_tryDevices.size()) {
+        // 当前设备不能上网，把当前主设备的never-default设为true，让下一个设备接住默认路由
+        qCDebug(DSM) << "Current device still cannot access internet, trying next device, index:" << m_tryIndex;
+        setPrimaryDeviceNeverDefault(true);
+        NetworkManager::Device::Ptr nextDevice = m_tryDevices.at(m_tryIndex);
+        changeDeviceNeverDefault(nextDevice, false);
+        m_tryIndex++;
+    } else {
+        // 所有设备都尝试过了，全部恢复
+        qCInfo(DSM) << "All devices tried, none can access internet, resetting all never-default";
+        resetAllNeverDefault();
+        m_tryIndex = 0;
+        m_isSwitching = false;
+        emit switchFailed();
+    }
+}
+
+void InternetChecker::onPrimaryConnectionTimeout()
+{
+    // NM在超时时间内没有切换主连接，可能是只有一个可切换的设备
+    qCWarning(DSM) << "PrimaryConnection change timeout, trying next device manually, index:" << m_tryIndex;
+    if (m_tryIndex < m_tryDevices.size()) {
+        // 把当前主设备的never-default设为true，让下一个设备接住默认路由
+        setPrimaryDeviceNeverDefault(true);
+        NetworkManager::Device::Ptr nextDevice = m_tryDevices.at(m_tryIndex);
+        changeDeviceNeverDefault(nextDevice, false);
+        m_tryIndex++;
+        // 重置超时定时器
+        m_switchTimer->start(5000);
+    } else {
+        resetAllNeverDefault();
+        m_tryIndex = 0;
+        m_isSwitching = false;
+        emit switchFailed();
+    }
+}
+
+void InternetChecker::switchInternetAccess()
+{
+    // 正在切换中，忽略新的切换请求
+    if (m_isSwitching) {
+        qCDebug(DSM) << "current is switching";
+        return;
+    }
+
+    m_isSwitching = true;
+    NetworkManager::Device::List availableDevice;
+    NetworkManager::Device::List devices = NetworkManager::networkInterfaces();
+    for (const NetworkManager::Device::Ptr &device : devices) {
+        if (device->type() != NetworkManager::Device::Type::Ethernet
+            && device->type() != NetworkManager::Device::Type::Wifi)
+            continue;
+        if (device->state() != NetworkManager::Device::State::Activated)
+            continue;
+
+        availableDevice << device;
+    }
+
+    if (availableDevice.size() <= 1) {
+        qCDebug(DSM) << "only one available device,it will reset all never default";
+        resetAllNeverDefault();
+        m_isSwitching = false;
+        return;
+    }
+
+    NetworkManager::ActiveConnection::Ptr primaryConnection = NetworkManager::primaryConnection();
+    if (primaryConnection.isNull()) {
+        qCWarning(DSM) << "primary connection is null, it will reset all never default";
+        resetAllNeverDefault();
+        m_isSwitching = false;
+        return;
+    }
+
+    // 找到当前主连接使用的网卡
+    QStringList primaryDeviceUnis = primaryConnection->devices();
+    NetworkManager::Device::Ptr primaryDevice;
+    for (const NetworkManager::Device::Ptr &device : availableDevice) {
+        if (primaryDeviceUnis.contains(device->uni())) {
+            primaryDevice = device;
+            qWarning() << "get primary device: " << primaryDevice->interfaceName();
+            break;
+        }
+    }
+
+    if (primaryDevice.isNull()) {
+        qWarning() << "primary device is null";
+        resetAllNeverDefault();
+        m_isSwitching = false;
+        return;
+    }
+
+    // 保存需要遍历的设备列表（排除当前主设备）
+    m_tryDevices.clear();
+    int primaryIdx = availableDevice.indexOf(primaryDevice);
+    for (int i = 1; i < availableDevice.size(); ++i) {
+        m_tryDevices << availableDevice.at((primaryIdx + i) % availableDevice.size());
+    }
+
+    if (m_tryDevices.isEmpty()) {
+        qCWarning(DSM) << "try device is empty";
+        resetAllNeverDefault();
+        m_isSwitching = false;
+        return;
+    }
+
+    // 先将第一个候选设备的never-default恢复为false，确保它能接住默认路由
+    changeDeviceNeverDefault(m_tryDevices.first(), false);
+    changeDeviceNeverDefault(primaryDevice, true);
+    m_tryIndex = 1;
+
+    // 设置超时定时器，防止NM没有触发信号时卡住
+    if (!m_switchTimer) {
+        m_switchTimer = new QTimer(this);
+        m_switchTimer->setSingleShot(true);
+        connect(m_switchTimer, &QTimer::timeout, this, &InternetChecker::onPrimaryConnectionTimeout);
+    }
+    m_switchTimer->start(5000);
+}

--- a/network-service-plugin/src/system/internetchecker.h
+++ b/network-service-plugin/src/system/internetchecker.h
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef INTERNETCHECKER_H
+#define INTERNETCHECKER_H
+
+#include <QObject>
+#include <NetworkManagerQt/Connection>
+#include <NetworkManagerQt/Device>
+
+class QTimer;
+
+namespace network {
+namespace systemservice {
+
+class InternetChecker : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit InternetChecker(QObject *parent = nullptr);
+    ~InternetChecker() override;
+    void switchInternetAccess();
+
+signals:
+    void switchSuccess();
+    void switchFailed();
+
+private slots:
+    void onPrimaryConnectionChanged(const QString &uni);
+    void onPrimaryConnectionTimeout();
+
+private:
+    void resetAllNeverDefault() const;
+    bool setConnectionNeverDefault(const NetworkManager::Connection::Ptr &conn, const NetworkManager::Device::Ptr &device, bool neverDefault) const;
+    void setPrimaryDeviceNeverDefault(bool neverDefault) const;
+    bool checkInternetAccessible() const;
+    bool checkInternetAccessible(int timeoutSec, bool &timedOut) const;
+    bool checkInternetAccessibleWithRetry(int maxRetry) const;
+    void changeDeviceNeverDefault(const NetworkManager::Device::Ptr &device, bool neverDefault) const;
+
+    int m_tryIndex;
+    NetworkManager::Device::List m_tryDevices;
+    QTimer *m_switchTimer;
+    bool m_isSwitching;
+};
+
+}
+}
+
+#endif // INTERNETCHECKER_H

--- a/network-service-plugin/src/utils/httpmanager.cpp
+++ b/network-service-plugin/src/utils/httpmanager.cpp
@@ -8,13 +8,75 @@
 
 #include <QRegularExpression>
 #include <QDebug>
+#include <QUrl>
 
 #include <mutex>
 #include <curl/curl.h>
 #include <sys/socket.h>
 #include <sys/time.h>
+#include <netdb.h>
+#include <arpa/inet.h>
+#include <pthread.h>
 
 using namespace network::service;
+
+namespace {
+
+struct GetAddrInfoParams {
+    const char *node;
+    const char *service;
+    const addrinfo *hints;
+    addrinfo *result = nullptr;
+    int ret = 0;
+};
+
+static void *getaddrinfo_thread(void *arg)
+{
+    auto *params = static_cast<GetAddrInfoParams *>(arg);
+    params->ret = getaddrinfo(params->node, params->service, params->hints, &params->result);
+    return nullptr;
+}
+
+// 在独立线程中执行 getaddrinfo，主线程等待 timeoutMs 毫秒
+// 如果超时返回 ETIMEDOUT，成功返回 0
+static int getaddrinfo_with_timeout(const char *node, const char *service,
+                                    const addrinfo *hints, addrinfo **result,
+                                    int timeoutMs)
+{
+    GetAddrInfoParams params = {node, service, hints, nullptr, 0};
+    pthread_t thread;
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+
+    if (pthread_create(&thread, &attr, getaddrinfo_thread, &params) != 0) {
+        pthread_attr_destroy(&attr);
+        return EAI_SYSTEM;
+    }
+    pthread_attr_destroy(&attr);
+
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts);
+    ts.tv_sec += timeoutMs / 1000;
+    ts.tv_nsec += (timeoutMs % 1000) * 1000000L;
+    if (ts.tv_nsec >= 1000000000L) {
+        ts.tv_sec += 1;
+        ts.tv_nsec -= 1000000000L;
+    }
+
+    void *threadRet = nullptr;
+    int joinRet = pthread_timedjoin_np(thread, &threadRet, &ts);
+    if (joinRet == ETIMEDOUT) {
+        // 线程超时，detach 让其自行结束（getaddrinfo 最终会返回）
+        pthread_detach(thread);
+        return ETIMEDOUT;
+    }
+
+    *result = params.result;
+    return params.ret;
+}
+
+} // anonymous namespace
 
 namespace network {
 namespace service {
@@ -105,11 +167,114 @@ HttpReply *HttpManager::get(const QString &url)
     if (curlRes == CURLE_OK) {
         reply->setHeader(QString::fromStdString(body_data));
     } else {
+        if (curlRes == CURLE_OPERATION_TIMEDOUT)
+            reply->setTimeout(true);
         const QString &errorMsg = curl_easy_strerror(curlRes);
         qCInfo(DSM) << "Request failed for" << url << ", error message:" << errorMsg;
         reply->setErrorMessage(errorMsg);
     }
 
+    curl_easy_cleanup(curl);
+    return reply;
+}
+
+HttpReply *HttpManager::get(const QString &url, int timeoutSec)
+{
+    HttpReply *reply = new HttpReply(this);
+
+    // 解析域名，使用系统 getaddrinfo，手动设置超时
+    QUrl qurl(url);
+    QString host = qurl.host();
+    int port = qurl.port(80);
+    QString resolvedIp;
+
+    if (!host.isEmpty()) {
+        addrinfo hints = {};
+        hints.ai_family = AF_UNSPEC;
+        hints.ai_socktype = SOCK_STREAM;
+        addrinfo *result = nullptr;
+
+        // getaddrinfo 本身会调用系统 DNS，如果路由器不通，glibc 会等待很久
+        // 用独立线程包装，只等待 timeoutSec 秒
+        // 注意：必须用局部变量持有 std::string，确保 getaddrinfo_with_timeout
+        // 返回前字符串生命周期有效，否则子线程会使用悬垂指针
+        std::string hostStd = host.toStdString();
+        int ret = getaddrinfo_with_timeout(hostStd.c_str(),
+                                            nullptr,
+                                            &hints,
+                                            &result,
+                                            timeoutSec * 1000);
+        if (ret == 0 && result != nullptr) {
+            char ipStr[INET6_ADDRSTRLEN];
+            if (result->ai_family == AF_INET) {
+                sockaddr_in *addr = reinterpret_cast<sockaddr_in *>(result->ai_addr);
+                inet_ntop(AF_INET, &addr->sin_addr, ipStr, sizeof(ipStr));
+            } else {
+                sockaddr_in6 *addr = reinterpret_cast<sockaddr_in6 *>(result->ai_addr);
+                inet_ntop(AF_INET6, &addr->sin6_addr, ipStr, sizeof(ipStr));
+            }
+            resolvedIp = QString::fromLatin1(ipStr);
+            freeaddrinfo(result);
+        } else if (ret == EAI_AGAIN || ret == EAI_NONAME || ret == ETIMEDOUT || ret == EAI_SYSTEM) {
+            // DNS 解析失败（超时或无此域名），直接返回超时
+            reply->setTimeout(true);
+            reply->setErrorMessage("DNS resolution timeout");
+            qCDebug(DSM) << "DNS resolution failed for" << host << "ret:" << ret;
+            return reply;
+        } else {
+            reply->setErrorMessage(QString("DNS resolution failed: %1").arg(gai_strerror(ret)));
+            qCInfo(DSM) << "DNS resolution failed for" << host << "error:" << gai_strerror(ret);
+            return reply;
+        }
+    }
+
+    CURL *curl = curl_easy_init();
+    if (!curl) {
+        qCWarning(DSM) << "Curl initialization failed for URL" << url;
+        reply->setErrorMessage("curl easy init failure");
+        return reply;
+    }
+
+    std::string urlStd = url.toStdString();
+    curl_easy_setopt(curl, CURLOPT_URL, urlStd);
+    curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(curl, CURLOPT_HTTPGET, 1);
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+    // 使用毫秒级超时
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(timeoutSec * 1000));
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, static_cast<long>(timeoutSec * 1000));
+    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_data);
+    std::string body_data;
+    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &body_data);
+    curl_easy_setopt(curl, CURLOPT_HEADER, 1L);
+    curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+    CurlSockoptContext sockCtx;
+    sockCtx.rwTimeoutSec = timeoutSec;
+    curl_easy_setopt(curl, CURLOPT_SOCKOPTFUNCTION, sockopt_callback);
+    curl_easy_setopt(curl, CURLOPT_SOCKOPTDATA, &sockCtx);
+
+    // 如果域名解析成功，通过 CURLOPT_RESOLVE 告诉 curl 直接使用该 IP，跳过 DNS 阶段
+    curl_slist *resolveList = nullptr;
+    if (!resolvedIp.isEmpty()) {
+        std::string resolveStr = host.toStdString() + ":" + std::to_string(port) + ":" + resolvedIp.toStdString();
+        resolveList = curl_slist_append(nullptr, resolveStr.c_str());
+        curl_easy_setopt(curl, CURLOPT_RESOLVE, resolveList);
+        qCDebug(DSM) << "DNS resolved" << host << "to" << resolvedIp << ", using CURLOPT_RESOLVE";
+    }
+
+    CURLcode curlRes = curl_easy_perform(curl);
+    if (curlRes == CURLE_OK) {
+        reply->setHeader(QString::fromStdString(body_data));
+    } else {
+        if (curlRes == CURLE_OPERATION_TIMEDOUT)
+            reply->setTimeout(true);
+        const QString &errorMsg = curl_easy_strerror(curlRes);
+        qCInfo(DSM) << "Request failed for" << url << ", error message:" << errorMsg;
+        reply->setErrorMessage(errorMsg);
+    }
+
+    if (resolveList)
+        curl_slist_free_all(resolveList);
     curl_easy_cleanup(curl);
     return reply;
 }
@@ -121,6 +286,7 @@ HttpReply *HttpManager::get(const QString &url)
 HttpReply::HttpReply(QObject *parent)
     : QObject (parent)
     , m_httpCode(0)
+    , m_timeout(false)
 {
 }
 
@@ -187,6 +353,16 @@ QString HttpReply::portal() const
 void HttpReply::setErrorMessage(const QString &errorMessage)
 {
     m_errorMessage = errorMessage;
+}
+
+void HttpReply::setTimeout(bool timeout)
+{
+    m_timeout = timeout;
+}
+
+bool HttpReply::isTimeout() const
+{
+    return m_timeout;
 }
 
 }

--- a/network-service-plugin/src/utils/httpmanager.h
+++ b/network-service-plugin/src/utils/httpmanager.h
@@ -24,6 +24,7 @@ public:
     ~HttpManager() override = default;
     // 调用GET方法
     HttpReply *get(const QString &url);
+    HttpReply *get(const QString &url, int timeoutSec);
 };
 
 /**
@@ -41,16 +42,19 @@ public:
     QString errorMessage() const;
     int httpCode() const;
     QString portal() const;
+    bool isTimeout() const;
 
 protected:
     explicit HttpReply(QObject *parent = Q_NULLPTR);
     void setHeader(const QString &html);
     void setErrorMessage(const QString &errorMessage);
+    void setTimeout(bool timeout);
 
 private:
     QString m_errorMessage;
     int m_httpCode;
     QString m_portalUrl;
+    bool m_timeout;
 };
 
 }

--- a/network-service-plugin/src/utils/settingconfig.cpp
+++ b/network-service-plugin/src/utils/settingconfig.cpp
@@ -84,6 +84,11 @@ int SettingConfig::httpConnectTimeout() const
     return m_httpConnectTimeout;
 }
 
+bool SettingConfig::needCheckNetwork() const
+{
+    return m_needCheckNetwork;
+}
+
 void SettingConfig::onValueChanged(const QString &key)
 {
     if (key == "reconnectIfIpConflicted") {
@@ -113,6 +118,8 @@ void SettingConfig::onValueChanged(const QString &key)
         m_httpConnectTimeout = dConfig->value("httpConnectTimeout").toInt();
     } else if (key == QString("portalProcessMode")) {
         m_protalProcessMode = dConfig->value("portalProcessMode").toString();
+    } else if (key == QString("needCheckNetwork")) {
+        m_needCheckNetwork = dConfig->value("needCheckNetwork").toBool();
     }
 }
 
@@ -126,6 +133,7 @@ SettingConfig::SettingConfig(QObject *parent)
     , m_enableAccountNetwork(false)
     , m_disableFailureNotify(false)
     , m_resetWifiOSDEnableTimeout(300)
+    , m_needCheckNetwork(true)
 {
     if (!dConfig)
         dConfig = Dtk::Core::DConfig::create("org.deepin.dde.network", "org.deepin.dde.network");
@@ -166,6 +174,9 @@ SettingConfig::SettingConfig(QObject *parent)
 
         if (keys.contains("httpConnectTimeout"))
             m_httpConnectTimeout = dConfig->value("httpConnectTimeout").toInt();
+
+        if (keys.contains("needCheckNetwork"))
+            m_needCheckNetwork = dConfig->value("needCheckNetwork").toBool();
 
         m_disableFailureNotify = dConfig->value("disableFailureNotify", false).toBool();
     }

--- a/network-service-plugin/src/utils/settingconfig.h
+++ b/network-service-plugin/src/utils/settingconfig.h
@@ -28,8 +28,7 @@ public:
 
     bool supportAutoOpenPortal() const;             // 是否支持自动打开网页
     bool supportPortalPromp() const;                // 是否支持在任务栏或控制中心给出提示
-    bool checkDeviceConnection() const;             // 是否检测设备连接
-    bool enableLocalNotify() const;
+    bool needCheckNetwork() const;                     // 是否需要检测网络
 
 signals:
     void enableConnectivityChanged(bool);
@@ -57,6 +56,7 @@ private:
     int m_resetWifiOSDEnableTimeout;
     int m_httpRequestTimeout;
     int m_httpConnectTimeout;
+    bool m_needCheckNetwork;
 };
 
 #endif // SERVICE_H


### PR DESCRIPTION
Add InternetChecker module to detect and switch the primary network interface when the current one cannot access the internet.

- Add InternetChecker class with switchInternetAccess() logic: traverse activated devices, check which ones can access internet, compare with current primary connection, and switch via never-default (updateUnsaved + reapplyConnection, not persisted to disk)
- Subscribe to NetworkManager::primaryConnectionChanged signal, retry connectivity checks after switch to wait for DHCP/route settling
- Reset all connections' never-default=false after successful switch or when all devices exhausted (via NetworkManager::Settings::listConnections
  + device active connections)
- Add needCheckNetwork config option to enable/disable the feature
- Integrate InternetChecker into LocalConnectionvityChecker, trigger on Limited/Noconnectivity/Unknownconnectivity states

增加检测单独网卡是否可以上网并自动切换网络的功能。

- 新增InternetChecker类，实现switchInternetAccess()逻辑：遍历所有已激活的网卡， 检测哪些网卡可以上网，与当前主连接网卡对比，若当前网卡不可上网则通过 never-default属性切换默认路由（使用updateUnsaved+reapplyConnection， 不持久化到磁盘）
- 监听NetworkManager::primaryConnectionChanged信号，切换后重试检测网络连通性， 等待DHCP/路由生效
- 切换成功后或所有设备都尝试过以后，重置所有连接的never-default为false （通过NetworkManager::Settings::listConnections遍历所有已保存连接， 并补充设备当前激活的连接，确保不遗漏）
- 新增needCheckNetwork配置项控制是否启用该功能
- 在LocalConnectionvityChecker中集成InternetChecker，在网络状态变为 Limited/Noconnectivity/Unknownconnectivity时触发检测和切换

PMS: BUG-351163