### PR TITLE
fix: call init() synchronously in DccNetwork constructor

### DIFF
--- a/dcc-network/operation/dccnetwork.cpp
+++ b/dcc-network/operation/dccnetwork.cpp
@@ -32,7 +32,7 @@ DccNetwork::DccNetwork(QObject *parent)
     qmlRegisterType<NetType>("org.deepin.dcc.network", 1, 0, "NetType");
     qmlRegisterType<NetItemModel>("org.deepin.dcc.network", 1, 0, "NetItemModel");
     qmlRegisterType<NetManager>("org.deepin.dcc.network", 1, 0, "NetManager");
-    QMetaObject::invokeMethod(this, "init", Qt::QueuedConnection);
+    init();
 }
 
 DccNetwork::~DccNetwork()


### PR DESCRIPTION
1. Replace QMetaObject::invokeMethod with direct init() call to prevent potential crash caused by deferred initialization

PMS: TASK-390967

fix: 在 DccNetwork 构造函数中同步调用 init()

1. 将 QMetaObject::invokeMethod 替换为直接调用 init()， 避免延迟初始化导致的潜在崩溃

PMS: TASK-390967

## Summary by Sourcery

Bug Fixes:
- Prevent potential crashes caused by deferred initialization of DccNetwork by removing the queued invokeMethod call and invoking init() directly in the constructor.