### PR TITLE
chore: update changelog to 2.0.92

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-network-core (2.0.92) unstable; urgency=medium
+
+  * feat(vpn): add VPN DNS mode configuration with systemd-resolved
+    integration
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 12 Jun 2026 14:24:20 +0800
+
 dde-network-core (2.0.91) unstable; urgency=medium
 
   * fix: prevent polkit popup when session is in background


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.92

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.92
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian package changelog entry to version 2.0.92 targeting master.