### PR TITLE
feat(vpn): Add dependency libpolkit-qt6-1-dev in control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,8 @@ Build-Depends: debhelper-compat (= 12),
                libdtk6widget-dev,
                libgsettings-qt6-dev,
                libkf6networkmanagerqt-dev,
-               libcurl4-openssl-dev
+               libcurl4-openssl-dev,
+               libpolkit-qt6-1-dev
 Rules-Requires-Root: no
 Standards-Version: 4.5.0
 Homepage: https://gerrit.uniontech.com/admin/repos/dde-network-core


### PR DESCRIPTION
Add dependency libpolkit-qt6-1-dev in control.

新增依赖 libpolkit-qt6-1-dev ，处理编译打包错误，支持 Polkit 权限认证。

Log: 新增依赖libpolkit-qt6-1-dev
PMS: BUG-355287
Influence: 正确编译打包

## Summary by Sourcery

Add missing polkit-related development dependency to the Debian packaging metadata to enable successful builds.

Bug Fixes:
- Fix Debian package build failures caused by a missing libpolkit-qt6-1-dev dependency.

Build:
- Declare libpolkit-qt6-1-dev as a required dependency in debian/control to support polkit-based permission handling.