### PR TITLE
chore: update changelog to 2.0.93

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-network-core (2.0.93) unstable; urgency=medium
+
+  * feat(vpn): Add dependency libpolkit-qt6-1-dev in control
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 12 Jun 2026 14:57:06 +0800
+
 dde-network-core (2.0.92) unstable; urgency=medium
 
   * feat(vpn): add VPN DNS mode configuration with systemd-resolved


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.93

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.93
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to release version 2.0.93 targeting master.