### PR TITLE
chore: update changelog to 2.0.94

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-network-core (2.0.94) unstable; urgency=medium
+
+  * feat: adopt xdg-activation protocol for Treeland dock plugin
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:17:47 +0800
+
 dde-network-core (2.0.93) unstable; urgency=medium
 
   * feat(vpn): Add dependency libpolkit-qt6-1-dev in control


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.94

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.94
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian package changelog entry to version 2.0.94 targeting master.