### PR TITLE
chore: update changelog to 2.0.95

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-network-core (2.0.95) unstable; urgency=medium
+
+  * fix: resolve network detection failure and ping-pong switching in
+    multi-NIC scenario
+  * chore: Sync by
+    https://github.com/linuxdeepin/.github/commit/88706fa723e3771211cb07
+    81d3d97fd4a6cd2a68
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 24 Jun 2026 15:35:08 +0800
+
 dde-network-core (2.0.94) unstable; urgency=medium
 
   * feat: adopt xdg-activation protocol for Treeland dock plugin


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 2.0.95

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 2.0.95
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 2.0.95 for the master branch.