### PR TITLE
fix(quick-panel): adjust icon and text color and hover effect in quic…

### DIFF
--- a/dock-network-plugin/quickpanelwidget.cpp
+++ b/dock-network-plugin/quickpanelwidget.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 ~ 2022 Deepin Technology Co., Ltd.
+// Copyright (C) 2022 ~ 2026 Deepin Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
@@ -68,6 +68,11 @@ QuickPanelWidget::QuickPanelWidget(QWidget *parent)
     , m_nameLabel(new DLabel(this))
     , m_stateLabel(new DLabel(this))
     , m_expandLabel(new DIconButton(this))
+    , m_iconOpacityEffect(new QGraphicsOpacityEffect(this))
+    , m_nameOpacityEffect(new QGraphicsOpacityEffect(this))
+    , m_stateOpacityEffect(new QGraphicsOpacityEffect(this))
+    , m_hover(false)
+    , m_active(true)
 {
     initUi();
     initConnection();
@@ -98,7 +103,9 @@ void QuickPanelWidget::setDescription(const QString &description)
 
 void QuickPanelWidget::setActive(bool active)
 {
+    m_active = active;
     m_iconWidget->setBackgroundRole(active ? QPalette::Highlight : QPalette::BrightText);
+    m_iconOpacityEffect->setOpacity(active ? 1.0 : (m_hover ? kHoverOpacity : kNormalOpacity));
 }
 
 void QuickPanelWidget::mousePressEvent(QMouseEvent *event)
@@ -125,6 +132,26 @@ void QuickPanelWidget::mouseReleaseEvent(QMouseEvent *event)
     }
     m_clickPoint = QPoint();
     return QWidget::mouseReleaseEvent(event);
+}
+ 
+void QuickPanelWidget::enterEvent(QEnterEvent *event)
+{
+    m_hover = true;
+    m_nameOpacityEffect->setOpacity(kHoverOpacity);
+    m_stateOpacityEffect->setOpacity(kHoverOpacity);
+    if (!m_active)
+        m_iconOpacityEffect->setOpacity(kHoverOpacity);
+    QWidget::enterEvent(event);
+}
+ 
+void QuickPanelWidget::leaveEvent(QEvent *event)
+{
+    m_hover = false;
+    m_nameOpacityEffect->setOpacity(kNormalOpacity);
+    m_stateOpacityEffect->setOpacity(kNormalOpacity);
+    if (!m_active)
+        m_iconOpacityEffect->setOpacity(kNormalOpacity);
+    QWidget::leaveEvent(event);
 }
 
 void QuickPanelWidget::initUi()
@@ -154,6 +181,15 @@ void QuickPanelWidget::initUi()
     m_iconWidget->setCheckable(false);
     m_iconWidget->setFixedSize(QSize(40, 40));
     m_iconWidget->setFocusPolicy(Qt::NoFocus);
+ 
+    m_iconOpacityEffect->setOpacity(kNormalOpacity);
+    m_iconWidget->setGraphicsEffect(m_iconOpacityEffect);
+ 
+    m_nameOpacityEffect->setOpacity(kNormalOpacity);
+    m_nameLabel->setGraphicsEffect(m_nameOpacityEffect);
+ 
+    m_stateOpacityEffect->setOpacity(kNormalOpacity);
+    m_stateLabel->setGraphicsEffect(m_stateOpacityEffect);
 
     // 进入图标
     m_expandLabel->setIcon(DStyle::standardIcon(style(), DStyle::SP_ArrowEnter));

--- a/dock-network-plugin/quickpanelwidget.h
+++ b/dock-network-plugin/quickpanelwidget.h
@@ -1,4 +1,4 @@
-// Copyright (C) 2022 ~ 2022 Deepin Technology Co., Ltd.
+// Copyright (C) 2022 ~ 2026 Deepin Technology Co., Ltd.
 // SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
@@ -10,6 +10,7 @@
 #include <DLabel>
 
 #include <QWidget>
+#include <QGraphicsOpacityEffect>
 
 class QLabel;
 
@@ -36,6 +37,8 @@ Q_SIGNALS:
     void iconClicked();
 
 protected:
+    void enterEvent(QEnterEvent *event) override;
+    void leaveEvent(QEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
 
@@ -48,6 +51,13 @@ private:
     Dtk::Widget::DLabel *m_nameLabel;
     Dtk::Widget::DLabel *m_stateLabel;
     Dtk::Widget::DIconButton *m_expandLabel;
+    QGraphicsOpacityEffect *m_iconOpacityEffect;
+    QGraphicsOpacityEffect *m_nameOpacityEffect;
+    QGraphicsOpacityEffect *m_stateOpacityEffect;
+    bool m_hover;
+    bool m_active;
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
     QPoint m_clickPoint;
 };
 } // namespace network

--- a/dock-network-plugin/widget/jumpsettingbutton.cpp
+++ b/dock-network-plugin/widget/jumpsettingbutton.cpp
@@ -22,6 +22,8 @@ JumpSettingButton::JumpSettingButton(QWidget *parent)
     , m_autoShowPage(true)
     , m_iconButton(new CommonIconButton(this))
     , m_descriptionLabel(new DLabel(this))
+    , m_iconOpacityEffect(new QGraphicsOpacityEffect(this))
+    , m_descOpacityEffect(new QGraphicsOpacityEffect(this))
 {
     initUI();
 }
@@ -32,6 +34,8 @@ JumpSettingButton::JumpSettingButton(const QIcon& icon, const QString& descripti
     , m_autoShowPage(true)
     , m_iconButton(new CommonIconButton(this))
     , m_descriptionLabel(new DLabel(this))
+    , m_iconOpacityEffect(new QGraphicsOpacityEffect(this))
+    , m_descOpacityEffect(new QGraphicsOpacityEffect(this))
 {
     initUI();
 
@@ -59,6 +63,13 @@ void JumpSettingButton::initUI()
     layout->setContentsMargins(10, 0, 10, 0);
     layout->addWidget(m_iconButton);
     layout->addWidget(m_descriptionLabel);
+ 
+    m_iconOpacityEffect->setOpacity(kNormalOpacity);
+    m_iconButton->setGraphicsEffect(m_iconOpacityEffect);
+ 
+    m_descOpacityEffect->setOpacity(kNormalOpacity);
+    m_descriptionLabel->setGraphicsEffect(m_descOpacityEffect);
+ 
     layout->addStretch();
 }
 
@@ -76,11 +87,16 @@ bool JumpSettingButton::event(QEvent* e)
 {
     switch (e->type()) {
     case QEvent::Leave:
-    case QEvent::Enter:
+    case QEvent::Enter: {
         m_hover = e->type() == QEvent::Enter;
+        qreal opacity = m_hover ? kHoverOpacity : kNormalOpacity;
+        m_iconOpacityEffect->setOpacity(opacity);
+        m_descOpacityEffect->setOpacity(opacity);
         update();
-        break;
+    } break;
     case QEvent::Hide:
+        m_iconOpacityEffect->setOpacity(kNormalOpacity);
+        m_descOpacityEffect->setOpacity(kNormalOpacity);
         m_hover = false;
         update();
         break;

--- a/dock-network-plugin/widget/jumpsettingbutton.h
+++ b/dock-network-plugin/widget/jumpsettingbutton.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
@@ -9,6 +9,7 @@
 
 #include <QFrame>
 #include <QLabel>
+#include <QGraphicsOpacityEffect>
 
 #include <DLabel>
 
@@ -44,6 +45,10 @@ private:
     QString m_secondPage;
     CommonIconButton *m_iconButton;
     Dtk::Widget::DLabel *m_descriptionLabel;
+    QGraphicsOpacityEffect *m_iconOpacityEffect;
+    QGraphicsOpacityEffect *m_descOpacityEffect;
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
 };
 
 #endif

--- a/net-view/window/private/netdelegate.cpp
+++ b/net-view/window/private/netdelegate.cpp
@@ -28,6 +28,7 @@
 #include <QTextLine>
 #include <QTextDocument>
 #include <QDesktopServices>
+#include <QGraphicsOpacityEffect>
 
 DWIDGET_USE_NAMESPACE
 
@@ -891,7 +892,10 @@ NetItemWidget::NetItemWidget(NetItem *item, QWidget *parent)
     : NetWidget (item, parent)
     , m_portalLabel (nullptr)
     , m_isEnter(false)
+    , m_opacityEffect(new QGraphicsOpacityEffect(this))
 {
+    m_opacityEffect->setOpacity(kNormalOpacity);
+    setGraphicsEffect(m_opacityEffect);
 }
 
 void NetItemWidget::removePasswordWidget()
@@ -912,6 +916,8 @@ void NetItemWidget::removePasswordWidget()
 
 void NetItemWidget::setHover(bool isHover)
 {
+    m_opacityEffect->setOpacity(isHover ? kHoverOpacity : kNormalOpacity);
+
     if (!m_portalLabel)
         return;
 

--- a/net-view/window/private/netdelegate.h
+++ b/net-view/window/private/netdelegate.h
@@ -13,6 +13,7 @@
 
 class QSortFilterProxyModel;
 class QVBoxLayout;
+class QGraphicsOpacityEffect;
 class QLabel;
 
 namespace Dtk {
@@ -181,6 +182,9 @@ private:
     QLabel *m_portalLabel;
     NetType::NetManagerFlags m_flag;
     bool m_isEnter;
+    QGraphicsOpacityEffect *m_opacityEffect;
+    static constexpr qreal kNormalOpacity = 0.7;
+    static constexpr qreal kHoverOpacity = 1.0;
 };
 
 class NetWirelessWidget : public NetItemWidget


### PR DESCRIPTION
…k panel

1. Add QGraphicsOpacityEffect to NetItemWidget for opacity-based dimming
2. Set normal state opacity to 0.7 and hover state opacity to 1.0
3. Apply graphics effect on widget initialization
4. Update opacity dynamically on hover state changes

Log: Adjust quick panel item icon/text colors and hover effect using opacity

fix(quick-panel): 调整快捷面板图标和文字颜色及 hover 效果

1. 为 NetItemWidget 添加 QGraphicsOpacityEffect 实现透明度效果
2. 设置正常状态透明度为 0.7，hover 状态透明度为 1.0
3. 在控件初始化时应用图形效果
4. 根据 hover 状态动态更新透明度

Log: 使用透明度调整快捷面板图标的颜色和 hover 效果
PMS: BUG-314503