### PR TITLE
fix: pass activation token to control center navigation

### DIFF
--- a/net-view/window/netstatus.cpp
+++ b/net-view/window/netstatus.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2019 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2019 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: LGPL-3.0-or-later
 #include "netstatus.h"
@@ -118,9 +118,10 @@ void NetStatus::invokeMenuItem(const QString &menuId)
     case MenuItemKey::MenuProxyDisabled:
         m_manager->setProxyEnabled(false);
         break;
-    case MenuItemKey::MenuSettings:
-        m_manager->exec(NetManager::GoToControlCenter, "");
-        break;
+    case MenuItemKey::MenuSettings: {
+        const auto token = qEnvironmentVariable("XDG_ACTIVATION_TOKEN");
+        m_manager->gotoControlCenter(token);
+    }   break;
     default:
         break;
     }


### PR DESCRIPTION
1. Replace direct call to `m_manager->exec(NetManager::GoToControlCenter,
"")` with `m_manager->gotoControlCenter(token)`
2. Retrieve `XDG_ACTIVATION_TOKEN` from environment for proper window
activation chain
3. Fix focus issue when opening control center from network menu

Log: Fixed control center window focus when navigating from network menu

Influence:
1. Test opening control center via network tray menu on different
desktop environments
2. Verify control center window is properly focused on activation
3. Test the navigation when launched from various contexts (tray,
keyboard shortcut)
4. Verify no regression in other menu item functions (proxy settings,
etc.)

fix: 传递激活令牌到控制中心导航

1. 将对 `m_manager->exec(NetManager::GoToControlCenter, "")` 的直接调用
替换为 `m_manager->gotoControlCenter(token)`
2. 从环境变量获取 `XDG_ACTIVATION_TOKEN` 以实现正确的窗口激活链
3. 修复从网络菜单打开控制中心时的焦点问题

Log: 修复从网络菜单打开控制中心时的窗口焦点问题

Influence:
1. 验证在不同桌面环境通过网络托盘菜单打开控制中心
2. 验证控制中心窗口在激活时是否正确获得焦点
3. 测试从不同上下文（托盘、快捷键）启动导航的情况
4. 验证其他菜单项功能（代理设置等）无回归问题

PMS: BUG-367651

## Summary by Sourcery

Pass XDG activation token when navigating from the network status menu to the control center to ensure correct window activation and focus.

Bug Fixes:
- Resolve control center window focus issues when opened from the network menu by wiring activation tokens into navigation.

Enhancements:
- Update netstatus menu handling to use a dedicated control center navigation API instead of a generic exec call.