### PR TITLE
fix(network): adjust font sizes on network details page

### DIFF
--- a/dcc-network/qml/PageDetails.qml
+++ b/dcc-network/qml/PageDetails.qml
@@ -107,6 +107,7 @@ DccObject {
                             delegate: ItemDelegate {
                                 implicitHeight: 36
                                 text: modelData[0]
+                                font: D.DTK.fontManager.t6
                                 checked: false
                                 backgroundVisible: true
                                 corners: getCornersForBackground(index, repeater.count)
@@ -118,6 +119,7 @@ DccObject {
                                     id: textInput
                                     text: modelData[1]
                                     color: palette.text
+                                    font: D.DTK.fontManager.t7
                                     selectedTextColor: palette.highlightedText
                                     selectionColor: palette.highlight
                                     readOnly: true


### PR DESCRIPTION
## Summary

Set proper font sizes on the Network Details page to align with the design spec:

1. Set left label text to T6 font size on detail list items
2. Set right content text to T7 font size on detail list items

## Changes

- `dcc-network/qml/PageDetails.qml`: Added explicit font declarations for ItemDelegate text (T6) and TextInput content (T7)

## Related

PMS: BUG-370973