### PR TITLE
feat(dconfig): add disableConnectingAnimation option for dock plugin

### DIFF
--- a/config/org.deepin.dde.network.json
+++ b/config/org.deepin.dde.network.json
@@ -351,15 +351,26 @@
             "visibility":"private"
          },
          "reapplyFlags":{
-            "value":2,
-            "serial":0,
-            "flags":["global"],
-            "name":"reapplyFlags",
-            "name[zh_CN]":"reapplyConnection标志位",
-            "description[zh_CN]":"reapplyConnection的标志位，只能是0、1、2三个值之一。0：无标志；1：保留外部配置(PRESERVE_EXTERNAL)；2：非阻塞(NONBLOCKING)",
-            "description":"Flags for reapplyConnection, must be 0, 1 or 2. 0: none; 1: PRESERVE_EXTERNAL; 2: NONBLOCKING",
-            "permissions":"readwrite",
-            "visibility":"private"
-         }
+             "value":2,
+             "serial":0,
+             "flags":["global"],
+             "name":"reapplyFlags",
+             "name[zh_CN]":"reapplyConnection标志位",
+             "description[zh_CN]":"reapplyConnection的标志位，只能是0、1、2三个值之一。0：无标志；1：保留外部配置(PRESERVE_EXTERNAL)；2：非阻塞(NONBLOCKING)",
+             "description":"Flags for reapplyConnection, must be 0, 1 or 2. 0: none; 1: PRESERVE_EXTERNAL; 2: NONBLOCKING",
+             "permissions":"readwrite",
+             "visibility":"private"
+          },
+         "disableConnectingAnimation":{
+             "value":false,
+             "serial":0,
+             "flags":[],
+             "name":"disableConnectingAnimation",
+             "name[zh_CN]":"禁用连接动画",
+             "description[zh_CN]":"当设置为true时，有线和无线网络在连接过程中不显示连接动画，保持未连接图标直到连接成功",
+             "description":"When set to true, wired and wireless network will not show connecting animation, keep disconnected icon until connected",
+             "permissions":"readwrite",
+             "visibility":"private"
+          }
     }
 }

--- a/net-view/window/netstatus.cpp
+++ b/net-view/window/netstatus.cpp
@@ -6,6 +6,7 @@
 #include "netitem.h"
 #include "netmanager.h"
 #include "networkconst.h"
+#include "configsetting.h"
 
 #include <QDebug>
 #include <QEvent>
@@ -804,49 +805,61 @@ void NetStatus::updateNetworkIcon()
         iconString = "network-none-symbolic";
         break;
     case NetworkStatus::Connecting: {
-        QStringList wirelessAnimation({
-                "network-wireless-signal-no-symbolic",
-                "network-wireless-signal-low-symbolic",
-                "network-wireless-signal-medium-symbolic",
-                "network-wireless-signal-high-symbolic",
-                "network-wireless-signal-full-symbolic",
-        });
-        m_animationIcon = QStringList({
-                "network-wired-symbolic-connecting1",
-                "network-wired-symbolic-connecting2",
-                "network-wired-symbolic-connecting3",
-                "network-wired-symbolic-connecting4",
-                "network-wired-symbolic-connecting5",
-                "network-wired-symbolic-connecting1",
-                "network-wired-symbolic-connecting2",
-                "network-wired-symbolic-connecting3",
-                "network-wired-symbolic-connecting4",
-                "network-wired-symbolic-connecting5",
+        if (ConfigSetting::instance()->disableConnectingAnimation()) {
+            iconString = "network-wireless-disconnect";
+        } else {
+            QStringList wirelessAnimation({
+                    "network-wireless-signal-no-symbolic",
+                    "network-wireless-signal-low-symbolic",
+                    "network-wireless-signal-medium-symbolic",
+                    "network-wireless-signal-high-symbolic",
+                    "network-wireless-signal-full-symbolic",
+            });
+            m_animationIcon = QStringList({
+                    "network-wired-symbolic-connecting1",
+                    "network-wired-symbolic-connecting2",
+                    "network-wired-symbolic-connecting3",
+                    "network-wired-symbolic-connecting4",
+                    "network-wired-symbolic-connecting5",
+                    "network-wired-symbolic-connecting1",
+                    "network-wired-symbolic-connecting2",
+                    "network-wired-symbolic-connecting3",
+                    "network-wired-symbolic-connecting4",
+                    "network-wired-symbolic-connecting5",
 
-        });
-        m_animationIcon.append(wirelessAnimation);
-        m_animationIcon.append(wirelessAnimation);
-        iconString = m_animationIcon.first();
+            });
+            m_animationIcon.append(wirelessAnimation);
+            m_animationIcon.append(wirelessAnimation);
+            iconString = m_animationIcon.first();
+        }
     } break;
     case NetworkStatus::WirelessConnecting: {
-        m_animationIcon = QStringList({
-                "network-wireless-signal-no-symbolic",
-                "network-wireless-signal-low-symbolic",
-                "network-wireless-signal-medium-symbolic",
-                "network-wireless-signal-high-symbolic",
-                "network-wireless-signal-full-symbolic",
-        });
-        iconString = m_animationIcon.first();
+        if (ConfigSetting::instance()->disableConnectingAnimation()) {
+            iconString = "network-wireless-disconnect";
+        } else {
+            m_animationIcon = QStringList({
+                    "network-wireless-signal-no-symbolic",
+                    "network-wireless-signal-low-symbolic",
+                    "network-wireless-signal-medium-symbolic",
+                    "network-wireless-signal-high-symbolic",
+                    "network-wireless-signal-full-symbolic",
+            });
+            iconString = m_animationIcon.first();
+        }
     } break;
     case NetworkStatus::WiredConnecting: {
-        m_animationIcon = QStringList({
-                "network-wired-symbolic-connecting1",
-                "network-wired-symbolic-connecting2",
-                "network-wired-symbolic-connecting3",
-                "network-wired-symbolic-connecting4",
-                "network-wired-symbolic-connecting5",
-        });
-        iconString = m_animationIcon.first();
+        if (ConfigSetting::instance()->disableConnectingAnimation()) {
+            iconString = "network-none-symbolic";
+        } else {
+            m_animationIcon = QStringList({
+                    "network-wired-symbolic-connecting1",
+                    "network-wired-symbolic-connecting2",
+                    "network-wired-symbolic-connecting3",
+                    "network-wired-symbolic-connecting4",
+                    "network-wired-symbolic-connecting5",
+            });
+            iconString = m_animationIcon.first();
+        }
     } break;
     case NetworkStatus::ConnectNoInternet:
     case NetworkStatus::WirelessConnectNoInternet: {
@@ -938,14 +951,18 @@ void NetStatus::updateQuick(unsigned wirelessStatus, unsigned wiredStatus)
         case NetType::DS_ObtainingIP:
         case NetType::DS_Connecting:
             quickDescription = tr("Connecting");
-            m_quickAnimationIcon = QStringList({
-                    "network-wireless-signal-no-symbolic",
-                    "network-wireless-signal-low-symbolic",
-                    "network-wireless-signal-medium-symbolic",
-                    "network-wireless-signal-high-symbolic",
-                    "network-wireless-signal-full-symbolic",
-            });
-            quickIconStr = m_quickAnimationIcon.first();
+            if (ConfigSetting::instance()->disableConnectingAnimation()) {
+                quickIconStr = "network-wireless-disconnect";
+            } else {
+                m_quickAnimationIcon = QStringList({
+                        "network-wireless-signal-no-symbolic",
+                        "network-wireless-signal-low-symbolic",
+                        "network-wireless-signal-medium-symbolic",
+                        "network-wireless-signal-high-symbolic",
+                        "network-wireless-signal-full-symbolic",
+                });
+                quickIconStr = m_quickAnimationIcon.first();
+            }
             break;
         case NetType::DS_IpConflicted:
             if (m_manager->primaryConnectionType() == NetManager::Wired
@@ -998,14 +1015,18 @@ void NetStatus::updateQuick(unsigned wirelessStatus, unsigned wiredStatus)
         case NetType::DS_ObtainingIP:
         case NetType::DS_Connecting:
             quickDescription = tr("Connecting");
-            m_quickAnimationIcon = QStringList({
-                    "network-wired-symbolic-connecting1",
-                    "network-wired-symbolic-connecting2",
-                    "network-wired-symbolic-connecting3",
-                    "network-wired-symbolic-connecting4",
-                    "network-wired-symbolic-connecting5",
-            });
-            quickIconStr = m_quickAnimationIcon.first();
+            if (ConfigSetting::instance()->disableConnectingAnimation()) {
+                quickIconStr = "network-none-symbolic";
+            } else {
+                m_quickAnimationIcon = QStringList({
+                        "network-wired-symbolic-connecting1",
+                        "network-wired-symbolic-connecting2",
+                        "network-wired-symbolic-connecting3",
+                        "network-wired-symbolic-connecting4",
+                        "network-wired-symbolic-connecting5",
+                });
+                quickIconStr = m_quickAnimationIcon.first();
+            }
             break;
         case NetType::DS_IpConflicted:
             if (m_manager->primaryConnectionType() == NetManager::Wireless

--- a/src/configsetting.cpp
+++ b/src/configsetting.cpp
@@ -32,6 +32,7 @@ ConfigSetting::ConfigSetting(QObject *parent)
     , m_browserUrl("https://www.uniontech.com")
     , m_nobindEthernetMacDefault(false)
     , m_portalProcessMode("promp")
+    , m_disableConnectingAnimation(false)
 {
     QStringList keys;
     if (!dConfig)
@@ -100,6 +101,8 @@ void ConfigSetting::onValueChanged(const QString &key)
         emit browserUrlChanged(m_browserUrl);
     } else if (key == "NobindEthernetMacDefault") {
         m_nobindEthernetMacDefault = dConfig->value("NobindEthernetMacDefault").toBool();
+    } else if (key == "disableConnectingAnimation") {
+        m_disableConnectingAnimation = dConfig->value("disableConnectingAnimation", false).toBool();
     }
 }
 
@@ -202,4 +205,9 @@ bool ConfigSetting::nobindEthernetMacDefault() const
 bool ConfigSetting::supportPortalPromp() const
 {
     return m_portalProcessMode.toLower().contains("promp");
+}
+
+bool ConfigSetting::disableConnectingAnimation() const
+{
+    return m_disableConnectingAnimation;
 }

--- a/src/configsetting.h
+++ b/src/configsetting.h
@@ -35,6 +35,7 @@ public:
     QString browserUrl() const;             // 文字链接打开浏览器时默认网址
     bool nobindEthernetMacDefault() const;  // 控制中心添加有线连接默认选择不绑定网卡
     bool supportPortalPromp() const;        // 是否在任务栏给出
+    bool disableConnectingAnimation() const; // 是否禁用连接动画
 
 signals:
     void checkUrlsChanged(const QStringList &);
@@ -76,6 +77,7 @@ private:
     QString m_browserUrl;
     bool m_nobindEthernetMacDefault;
     QString m_portalProcessMode;
+    bool m_disableConnectingAnimation;
 };
 
 } // namespace network


### PR DESCRIPTION
Add a new DConfig option "disableConnectingAnimation" to control whether the dock network plugin shows connecting animation. When set to true, wired and wireless network will keep showing disconnected icons during the connecting phase, and switch to connected icons only after connection succeeds. The configuration takes effect in real-time.

新增dconfig配置项"disableConnectingAnimation"，控制dock网络插件是否显示连接动画。设置为true时，有线和无线网络在连接过程中保持未连接图标，连接成功后切换为已连接图标。配置变更实时生效。

Log: 新增dconfig配置项支持禁用dock网络连接动画
PMG: Task-392929
Influence: 通过dconfig设置disableConnectingAnimation为true后，dock面板中有线和无线网络连接过程不再显示动画，保持未连接状态图标，连接成功后正常显示连接图标。