### PR TITLE
feat(dconfig): add disableAllNotify option to disable all network not…

### DIFF
--- a/config/org.deepin.dde.network.json
+++ b/config/org.deepin.dde.network.json
@@ -370,6 +370,17 @@
              "description[zh_CN]":"当设置为true时，有线和无线网络在连接过程中不显示连接动画，保持未连接图标直到连接成功",
              "description":"When set to true, wired and wireless network will not show connecting animation, keep disconnected icon until connected",
              "permissions":"readwrite",
+              "visibility":"private"
+           },
+         "disableAllNotify":{
+             "value":false,
+             "serial":0,
+             "flags":["global"],
+             "name":"disableAllNotify",
+             "name[zh_CN]":"禁用所有网络通知",
+             "description[zh_CN]":"当设置为true时，禁用所有网络连接相关的通知消息，包括连接成功、连接失败、断开连接等",
+             "description":"When set to true, disable all network connection notifications, including connected, failed, disconnected, etc.",
+             "permissions":"readwrite",
              "visibility":"private"
           }
     }

--- a/net-view/operation/private/netmanagerthreadprivate.cpp
+++ b/net-view/operation/private/netmanagerthreadprivate.cpp
@@ -330,6 +330,8 @@ void NetManagerThreadPrivate::sendNotify(const QString &appIcon, const QString &
 {
     if (!m_enabled)
         return;
+    if (ConfigSetting::instance()->disableAllNotify())
+        return;
     Q_EMIT networkNotify(inAppName, replacesId, appIcon, summary, body, actions, hints, expireTimeout);
 }
 

--- a/network-service-plugin/src/session/networkstatehandler.cpp
+++ b/network-service-plugin/src/session/networkstatehandler.cpp
@@ -650,6 +650,10 @@ void NetworkStateHandler::notify(const QString &icon, const QString &summary, co
         qCDebug(DSM()) << "notify disabled";
         return;
     }
+    if (SettingConfig::instance()->disableAllNotify()) {
+        qCDebug(DSM()) << "disable all notify";
+        return;
+    }
 
     QDBusMessage msg = QDBusMessage::createMethodCall("org.freedesktop.Notifications", "/org/freedesktop/Notifications", "org.freedesktop.Notifications", "Notify");
     const QStringList actions;

--- a/network-service-plugin/src/utils/settingconfig.cpp
+++ b/network-service-plugin/src/utils/settingconfig.cpp
@@ -69,6 +69,11 @@ bool SettingConfig::disableFailureNotify() const
     return m_disableFailureNotify;
 }
 
+bool SettingConfig::disableAllNotify() const
+{
+    return m_disableAllNotify;
+}
+
 int SettingConfig::resetWifiOSDEnableTimeout() const
 {
     return m_resetWifiOSDEnableTimeout;
@@ -114,6 +119,8 @@ void SettingConfig::onValueChanged(const QString &key)
     } else if (key == QString("disableFailureNotify")) {
         m_disableFailureNotify = dConfig->value("disableFailureNotify").toBool();
         emit disableFailureNotifyChanged(m_disableFailureNotify);
+    } else if (key == QString("disableAllNotify")) {
+        m_disableAllNotify = dConfig->value("disableAllNotify", false).toBool();
     } else if (key == QString("resetWifiOSDEnableTimeout")) {
         m_resetWifiOSDEnableTimeout = dConfig->value("resetWifiOSDEnableTimeout").toInt();
         emit resetWifiOSDEnableTimeoutChanged(m_resetWifiOSDEnableTimeout);
@@ -140,6 +147,7 @@ SettingConfig::SettingConfig(QObject *parent)
     , m_disabledNetwork(false)
     , m_enableAccountNetwork(false)
     , m_disableFailureNotify(false)
+    , m_disableAllNotify(false)
     , m_resetWifiOSDEnableTimeout(300)
     , m_needCheckNetwork(true)
     , m_reapplyFlags(2)

--- a/network-service-plugin/src/utils/settingconfig.h
+++ b/network-service-plugin/src/utils/settingconfig.h
@@ -22,6 +22,7 @@ public:
     bool disableNetwork() const;            // 是否禁用无线网络和蓝牙
     bool enableAccountNetwork() const;      // 是否开启用户私有网络(工银瑞信定制)
     bool disableFailureNotify() const;      // 当网络连接失败后,true:不弹出消息,false:弹出消息
+    bool disableAllNotify() const;          // 是否禁用所有网络通知
     int resetWifiOSDEnableTimeout() const;  // 重新显示网络连接OSD超时
     int httpRequestTimeout() const;                 // HTTP请求超时时间（秒）
     int httpConnectTimeout() const;                 // HTTP连接超时时间（秒）
@@ -54,6 +55,7 @@ private:
     bool m_disabledNetwork;
     bool m_enableAccountNetwork;
     bool m_disableFailureNotify;
+    bool m_disableAllNotify;
     int m_resetWifiOSDEnableTimeout;
     int m_httpRequestTimeout;
     int m_httpConnectTimeout;

--- a/src/configsetting.cpp
+++ b/src/configsetting.cpp
@@ -33,6 +33,7 @@ ConfigSetting::ConfigSetting(QObject *parent)
     , m_nobindEthernetMacDefault(false)
     , m_portalProcessMode("promp")
     , m_disableConnectingAnimation(false)
+    , m_disableAllNotify(false)
 {
     QStringList keys;
     if (!dConfig)
@@ -103,6 +104,8 @@ void ConfigSetting::onValueChanged(const QString &key)
         m_nobindEthernetMacDefault = dConfig->value("NobindEthernetMacDefault").toBool();
     } else if (key == "disableConnectingAnimation") {
         m_disableConnectingAnimation = dConfig->value("disableConnectingAnimation", false).toBool();
+    } else if (key == "disableAllNotify") {
+        m_disableAllNotify = dConfig->value("disableAllNotify", false).toBool();
     }
 }
 
@@ -210,4 +213,9 @@ bool ConfigSetting::supportPortalPromp() const
 bool ConfigSetting::disableConnectingAnimation() const
 {
     return m_disableConnectingAnimation;
+}
+
+bool ConfigSetting::disableAllNotify() const
+{
+    return m_disableAllNotify;
 }

--- a/src/configsetting.h
+++ b/src/configsetting.h
@@ -36,6 +36,7 @@ public:
     bool nobindEthernetMacDefault() const;  // 控制中心添加有线连接默认选择不绑定网卡
     bool supportPortalPromp() const;        // 是否在任务栏给出
     bool disableConnectingAnimation() const; // 是否禁用连接动画
+    bool disableAllNotify() const;           // 是否禁用所有网络通知
 
 signals:
     void checkUrlsChanged(const QStringList &);
@@ -78,6 +79,7 @@ private:
     bool m_nobindEthernetMacDefault;
     QString m_portalProcessMode;
     bool m_disableConnectingAnimation;
+    bool m_disableAllNotify;
 };
 
 } // namespace network


### PR DESCRIPTION
…ifications

Add a new DConfig option "disableAllNotify" to control whether all network notifications are sent. When set to true, both frontend and backend notification paths are blocked, covering connected, failed, disconnected and all other network events.

新增dconfig配置项"disableAllNotify"，控制是否禁用所有网络通知。设置为true时，前端和后端两条通知路径均被拦截，所有网络连接相关通知不再发送。

Log: 新增dconfig配置项支持禁用所有网络通知
PMG: Task-392929
Influence: 通过dconfig设置disableAllNotify为true后，所有网络连接通知（连接成功、连接失败、断开连接等）均不再发送。