### PR TITLE
fix(hotspot): align title font weight and color with Shared Settings

### DIFF
--- a/dcc-network/qml/PageHotspot.qml
+++ b/dcc-network/qml/PageHotspot.qml
@@ -180,10 +180,15 @@ DccObject {
             page: RowLayout {
                 Label {
                     font: DccUtils.copyFont(D.DTK.fontManager.t5, {
-                                       "weight": 700
+                                       "weight": 500
                                    })
                     text: dccObj.displayName
                     Layout.alignment: Qt.AlignLeft
+                    property D.Palette textColor: D.Palette {
+                        normal: Qt.rgba(0, 0, 0, 0.9)
+                        normalDark: Qt.rgba(1, 1, 1, 0.9)
+                    }
+                    color: D.ColorSelector.textColor
                 }
                 D.ActionButton {
                     Layout.alignment: Qt.AlignRight


### PR DESCRIPTION
## Issue

The "My Hotspot" title on the personal hotspot page has incorrect font weight and color, inconsistent with the "Shared Settings" title below.

## Changes

1. Change the My Hotspot title label font weight from 700 to 500
2. Add D.Palette textColor and D.ColorSelector.textColor to match DccTitleObject default color

Log: Align My Hotspot title font weight and color with Shared Settings
Influence: Hotspot page title style matches Shared Settings

## 问题

个人热点页面"我的热点"标题字重和颜色与下方"共享设置"不一致。

## 修改

1. 将"我的热点"标题标签字重从 700 改为 500
2. 添加 D.Palette textColor 和 D.ColorSelector.textColor，与 DccTitleObject 默认颜色一致

Log: 对齐我的热点标题字重和颜色与共享设置一致
PMS: BUG-371463
Influence: 热点页面标题样式与共享设置一致