### PR TITLE
chore: add polkit policy to debian install

### DIFF
--- a/debian/libdde-network-core.install
+++ b/debian/libdde-network-core.install
@@ -1,3 +1,4 @@
 usr/lib/*/libdde-network-core*.so*
 usr/share/dsg/configs/*
 usr/share/dde-network-core/translations
+usr/share/polkit-1/actions/com.deepin.dde.network.policy


### PR DESCRIPTION
Add the polkit policy action file to the libdde-network-core package to ensure correct installation and enable proper privilege escalation for network management operations.

Log: Added polkit policy file for network management

Influence:
1. Verify that the polkit policy file is installed in the correct location: /usr/share/polkit-1/actions/com.deepin.dde.network.policy
2. Test that network operations requiring privileges now work correctly (e.g., changing network settings, connecting to networks)
3. Ensure no existing functionality is broken by the addition of the policy file

chore: 添加 polkit 策略到 debian 安装

将 polkit 策略配置文件添加入 libdde-network-core 包中，确保其能被正确安 装，从而为网络管理操作提供正确的权限提升支持。

Log: 新增网络管理 polkit 策略文件
PMS: BUG-355287
Influence:
1. 确认 polkit 策略文件被安装在正确位置：/usr/share/polkit-1/actions/ com.deepin.dde.network.policy
2. 测试需要特权的网络操作是否能正常工作（例如：更改网络设置、连接网 络等）
3. 确保添加策略文件不会破坏现有功能

## Summary by Sourcery

Build:
- Include the com.deepin.dde.network.policy polkit action file in the libdde-network-core Debian package installation paths.