### PR TITLE
fix(airplane): use T8 font size and add 12px left padding for tips label

### DIFF
--- a/dcc-network/qml/PageAirplane.qml
+++ b/dcc-network/qml/PageAirplane.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.15

--- a/dcc-network/qml/PageAirplane.qml
+++ b/dcc-network/qml/PageAirplane.qml
@@ -64,6 +64,8 @@ DccObject {
             page: D.Label {
                 text: dccObj.displayName
                 wrapMode: Text.WordWrap
+                font.pixelSize: D.DTK.fontManager.t8.pixelSize
+                leftPadding: 12
             }
         }
     }


### PR DESCRIPTION
## Issue

The airplane mode tips label uses a default font size that is too large, and has no left padding, causing misalignment with list items below.

## Changes

1. Change the airplane mode tips label font size to T8 (D.DTK.fontManager.t8.pixelSize)
2. Add 12px left padding (leftPadding: 12) to align the text with the list items

Log: Fix airplane mode tips label font size and left padding
Influence: Airplane tips text aligns with list items

## 问题

飞行模式页面提示文字字号偏大，且没有左边距，与下方列表项未对齐。

## 修改

1. 将提示文字字号从默认大小改为 T8（D.DTK.fontManager.t8.pixelSize）
2. 添加 12px 左边距（leftPadding: 12），使文字左侧与列表左侧对齐

Log: 修复飞行模式页面提示文字字号和左边距问题
PMS: BUG-371531
Influence: 飞行模式提示文字与列表项对齐