### PR TITLE
fix(wireless): fix title font weight and color for My/Other Networks

### DIFF
--- a/dcc-network/qml/PageWirelessDevice.qml
+++ b/dcc-network/qml/PageWirelessDevice.qml
@@ -295,9 +295,16 @@ DccObject {
             pageType: DccObject.Item
             page: Label {
                 font: DccUtils.copyFont(D.DTK.fontManager.t5, {
-                                            "bold": true
+                                            "weight": Font.Medium
                                         })
                 text: dccObj.displayName
+                color: D.ColorSelector.textColor
+                D.Palette {
+                    id: mineTitleColor
+                    normal: Qt.rgba(0, 0, 0, 0.9)
+                    normalDark: Qt.rgba(1, 1, 1, 0.9)
+                }
+                property D.Palette textColor: mineTitleColor
             }
             onParentItemChanged: {
                 if (parentItem) {
@@ -328,9 +335,16 @@ DccObject {
             pageType: DccObject.Item
             page: Label {
                 font: DccUtils.copyFont(D.DTK.fontManager.t6, {
-                                            "bold": true
+                                            "weight": Font.Medium
                                         })
                 text: dccObj.displayName
+                color: D.ColorSelector.textColor
+                D.Palette {
+                    id: otherTitleColor
+                    normal: Qt.rgba(0, 0, 0, 0.9)
+                    normalDark: Qt.rgba(1, 1, 1, 0.9)
+                }
+                property D.Palette textColor: otherTitleColor
 
                 Timer {
                     id: refreshTimer


### PR DESCRIPTION
1. Change "My Networks" title font weight from bold to Font.Medium
2. Change "Other Networks" title font weight from bold to Font.Medium, keep t6 font size
3. Apply DccTitleObject-style palette color (rgba 0.9 alpha) to both titles to match "My Hotspot"

Log: Fix wireless page section titles font weight and color to match hotspot title style
Influence: Section titles now match hotspot title style

fix(wireless): 修复无线网络"我的网络"和"其他网络"标题字重和颜色

1. 将"我的网络"标题字重从 bold 改为 Font.Medium
2. 将"其他网络"标题字重从 bold 改为 Font.Medium，保持 t6 字号不变
3. 为两个标题应用与"我的热点"一致的 DccTitleObject 调色板颜色（rgba 0.9 透明度）

Log: 修复无线网络页面分区标题字重和颜色与热点标题不一致的问题
PMS: BUG-371529
Influence: 标题样式与个人热点模块保持一致

## Summary by Sourcery

Align wireless page section titles and airplane mode page header styling with the hotspot title and global typography guidelines.

Bug Fixes:
- Correct font weight and color for "My Networks" and "Other Networks" titles to match hotspot styling.
- Ensure airplane mode page header uses the appropriate font size and padding for consistent layout.

Enhancements:
- Apply shared palette-based title colors for wireless section labels to improve visual consistency across themes.