### PR TITLE
feat: add DConfig to control dock network icon interaction

### DIFF
--- a/config/org.deepin.dde.network.json
+++ b/config/org.deepin.dde.network.json
@@ -372,6 +372,17 @@
              "permissions":"readwrite",
               "visibility":"private"
            },
+         "enableDockNetworkClick": {
+             "value": true,
+             "serial": 0,
+             "flags": [],
+             "name": "Enable Dock Network Interaction",
+             "name[zh_CN]": "启用任务栏网络图标交互",
+             "description": "Enable or disable click, touch long-press, and hover interaction on the network icon in the dock. When disabled, the tooltip is not shown. The quick panel network entry is not affected.",
+             "description[zh_CN]": "启用或禁用任务栏网络图标的点击、触摸长按及悬停交互；关闭时不显示提示信息，不影响快捷面板中的网络入口。",
+             "permissions": "readwrite",
+             "visibility": "private"
+          },
          "disableAllNotify":{
              "value":false,
              "serial":0,

--- a/dock-network-plugin/CMakeLists.txt
+++ b/dock-network-plugin/CMakeLists.txt
@@ -38,7 +38,7 @@ set(CMAKE_PREFER_PTHREAD_FLAG ON)
 
 find_package(${QT_NS} COMPONENTS Core Widgets DBus Network WaylandClient LinguistTools REQUIRED)
 find_package(PkgConfig REQUIRED)
-find_package(${DTK_NS} REQUIRED COMPONENTS Widget)
+find_package(${DTK_NS} REQUIRED COMPONENTS Core Widget)
 find_package(KF6NetworkManagerQt REQUIRED)
 find_package(DdeDock REQUIRED)
 
@@ -82,6 +82,7 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
     ${QT_NS}::DBus
     ${QT_NS}::Network
     ${QT_NS}::WaylandClientPrivate
+    ${DTK_NS}::Core
     ${DTK_NS}::Widget
     KF6::NetworkManagerQt
     dde-network-core6

--- a/dock-network-plugin/networkplugin.cpp
+++ b/dock-network-plugin/networkplugin.cpp
@@ -10,6 +10,7 @@
 #include "netview.h"
 #include "quickpanelwidget.h"
 
+#include <DConfig>
 #include <DGuiApplicationHelper>
 
 #include "xdgactivation.h"
@@ -28,6 +29,10 @@ DGUI_USE_NAMESPACE
 
 static Q_LOGGING_CATEGORY(DNC, "org.deepin.dde.dock.network");
 
+namespace {
+constexpr auto EnableDockNetworkClickKey = "enableDockNetworkClick";
+}
+
 namespace dde {
 namespace network {
 NetworkPlugin::NetworkPlugin(QObject *parent)
@@ -37,15 +42,28 @@ NetworkPlugin::NetworkPlugin(QObject *parent)
     , m_manager(nullptr)
     , m_netView(nullptr)
     , m_netStatus(nullptr)
+    , m_dconfig(Dtk::Core::DConfig::create(QStringLiteral("org.deepin.dde.network"),
+                                           QStringLiteral("org.deepin.dde.network"),
+                                           QString(),
+                                           this))
     , m_isLockScreen(false)
     , m_replacesId(0)
     , m_dockContentWidget(nullptr)
     , m_netCheckAvailable(false)
     , m_netLimited(false)
+    , m_enableDockNetworkClick(true)
 {
     QTranslator *translator = new QTranslator(this);
     if (translator->load(QLocale(), "dock-network-plugin", "_", "/usr/share/dock-network-plugin/translations")) {
         QCoreApplication::installTranslator(translator);
+    }
+
+    if (m_dconfig && m_dconfig->isValid()) {
+        connect(m_dconfig, &Dtk::Core::DConfig::valueChanged,
+                this, &NetworkPlugin::updateDockClickSettings);
+        updateDockClickSettings();
+    } else {
+        qCWarning(DNC) << "Unable to create network DConfig; dock icon interactions remain enabled";
     }
 }
 
@@ -65,6 +83,28 @@ NetworkPlugin::~NetworkPlugin()
 
     if (m_trayIcon)
         m_trayIcon->deleteLater();
+}
+
+void NetworkPlugin::updateDockClickSettings(const QString &key)
+{
+    if (!m_dconfig || !m_dconfig->isValid())
+        return;
+
+    if (!key.isEmpty() && key != QLatin1String(EnableDockNetworkClickKey))
+        return;
+
+    const bool enabled = m_dconfig->value(QLatin1String(EnableDockNetworkClickKey), true).toBool();
+    if (enabled == m_enableDockNetworkClick)
+        return;
+
+    m_enableDockNetworkClick = enabled;
+
+    if (!m_enableDockNetworkClick && m_trayIcon && m_trayIcon->parentWidget()) {
+        QEvent leaveEvent(QEvent::Leave);
+        QCoreApplication::sendEvent(m_trayIcon->parentWidget(), &leaveEvent);
+    }
+
+    qCInfo(DNC) << "Dock network interaction setting changed:" << m_enableDockNetworkClick;
 }
 
 const QString NetworkPlugin::pluginName() const
@@ -263,6 +303,9 @@ void NetworkPlugin::refreshPluginItemsVisible()
 
 bool NetworkPlugin::eventFilter(QObject *watched, QEvent *event)
 {
+    const bool isDockIcon = m_trayIcon
+            && (watched == m_trayIcon || watched == m_trayIcon->parentWidget());
+
     switch (event->type()) {
     case QEvent::ParentChange: {
         if (watched == m_trayIcon && m_trayIcon->parentWidget()) {
@@ -274,8 +317,31 @@ bool NetworkPlugin::eventFilter(QObject *watched, QEvent *event)
         if (m_trayIcon && watched == m_trayIcon->parentWidget())
             updateIconColor();
     } break;
+    case QEvent::MouseButtonPress:
+    case QEvent::MouseButtonRelease:
+    case QEvent::MouseButtonDblClick:
+    case QEvent::ContextMenu:
+    case QEvent::TouchBegin:
+    case QEvent::TouchUpdate:
+    case QEvent::TouchEnd:
+    case QEvent::TouchCancel: {
+        if (isDockIcon && !m_enableDockNetworkClick)
+            return true;
+    } break;
     case QEvent::Enter:
-    case QEvent::MouseMove: {
+    case QEvent::HoverEnter:
+    case QEvent::HoverMove:
+    case QEvent::MouseMove:
+    case QEvent::ToolTip: {
+        if (!isDockIcon)
+            break;
+
+        if (!m_enableDockNetworkClick)
+            return true;
+
+        if (event->type() != QEvent::Enter && event->type() != QEvent::MouseMove)
+            break;
+
         const QPoint &p = m_trayIcon->mapFromGlobal(QCursor::pos());
         const bool isHorizontal = position() == Dock::Top || position() == Dock::Bottom;
         m_netStatus->setHoverTips((isHorizontal ? p.x() : p.y()) > ((isHorizontal ? m_trayIcon->width() : m_trayIcon->height()) / 2) && m_netStatus->vpnAndProxyIconVisibel()

--- a/dock-network-plugin/networkplugin.h
+++ b/dock-network-plugin/networkplugin.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,6 +22,12 @@
 #define NETWORK_KEY "network-item-key"
 
 class QDBusMessage;
+
+namespace Dtk {
+namespace Core {
+class DConfig;
+}
+}
 
 namespace dde {
 namespace network {
@@ -94,6 +100,7 @@ protected:
 private:
     void loadPlugin();
     void refreshPluginItemsVisible();
+    void updateDockClickSettings(const QString &key = QString());
     bool eventFilter(QObject *watched, QEvent *event) override;
 
 private:
@@ -102,12 +109,14 @@ private:
     dde::network::NetManager *m_manager;
     dde::network::NetView *m_netView;
     dde::network::NetStatus *m_netStatus;
+    Dtk::Core::DConfig *m_dconfig;
     QPointer<QuickPanelWidget> m_quickPanel;
     bool m_isLockScreen;
     uint m_replacesId;
     DockContentWidget *m_dockContentWidget;
     bool m_netCheckAvailable;
     bool m_netLimited;
+    bool m_enableDockNetworkClick;
 };
 } // namespace network
 } // namespace dde


### PR DESCRIPTION
Added a DConfig-based setting to enable or disable click, touch, and hover interactions on the dock network icon. This allows users to prevent accidental interactions while keeping the quick panel entry unaffected.

Log: Add DConfig support for dock network icon interaction control

Influence:
1. Verify that dock network icon click, touch long-press, and hover interactions work when setting is enabled (default)
2. Test that interactions are disabled when setting is disabled
3. Verify tooltip does not appear when setting is disabled
4. Ensure quick panel network entry remains functional regardless of setting
5. Test that the setting change takes effect without restarting the dock
6. Check that no visual artifacts or crashes occur after toggling the setting

feat: 新增 DConfig 控制任务栏网络图标交互

添加基于 DConfig 的配置项，用于启用或禁用任务栏网络图标的点击、触摸和悬
停交互。这允许用户避免意外操作，同时不影响快捷面板中的网络入口。

Log: 新增任务栏网络图标交互控制的 DConfig 支持

Influence:
1. 验证启用设置（默认）时，任务栏网络图标的点击、触摸长按和悬停交互正常 工作
2. 测试禁用设置后，交互功能被关闭
3. 验证禁用设置后不显示提示信息
4. 确保快捷面板网络入口不受设置影响，始终可用
5. 测试设置更改后无需重启任务栏即可生效
6. 检查切换设置后不会出现视觉异常或崩溃

PMS: TASK-393299