### PR TITLE
fix(dock): show connected status when disableConnectingAnimation is true

### DIFF
--- a/net-view/window/netstatus.cpp
+++ b/net-view/window/netstatus.cpp
@@ -579,6 +579,25 @@ void NetStatus::doUpdateStatus()
     iphtml[WIRED_DEVICE_INDEX].sort();
 
     unsigned netStatus = devStatus[WIRELESS_DEVICE_INDEX] | devStatus[WIRED_DEVICE_INDEX];
+    // 当禁用连接动画时，遍历所有网卡，如果有任意网卡已连接，则不让连接中状态覆盖已连接状态
+    if (ConfigSetting::instance()->disableConnectingAnimation()) {
+        bool hasConnectingState = (netStatus == NetType::DS_Connecting) ||
+                                  (netStatus == NetType::DS_ObtainingIP) ||
+                                  (netStatus == NetType::DS_Authenticating);
+        if (hasConnectingState) {
+            for (const auto &it : root->getChildren()) {
+                if (it->itemType() != NetType::WiredDeviceItem && it->itemType() != NetType::WirelessDeviceItem)
+                    continue;
+
+                NetDeviceItem *devItem = qobject_cast<NetDeviceItem *>(it);
+                if (!devItem || devItem->status() != NetType::DS_Connected)
+                    continue;
+
+                netStatus = NetType::DS_Connected;
+                break;
+            }
+        }
+    }
     bool isWirelessStatus = netStatus == devStatus[WIRELESS_DEVICE_INDEX];
     NetworkStatus networkStatus = NetworkStatus::Unknown;
     // 汇总有线无线状态

--- a/network-service-plugin/src/utils/settingconfig.cpp
+++ b/network-service-plugin/src/utils/settingconfig.cpp
@@ -195,6 +195,9 @@ SettingConfig::SettingConfig(QObject *parent)
         if (keys.contains("needCheckNetwork"))
             m_needCheckNetwork = dConfig->value("needCheckNetwork").toBool();
 
+        if (keys.contains("disableAllNotify"))
+            m_disableAllNotify = dConfig->value("disableAllNotify", false).toBool();
+
         m_disableFailureNotify = dConfig->value("disableFailureNotify", false).toBool();
 
         if (keys.contains("reapplyFlags")) {


### PR DESCRIPTION
When disableConnectingAnimation is set to true and multiple NICs exist,if one NIC is connected while another is connecting, the icon would incorrectly show disconnected state. Now traverse all NICs to check if any is connected, and display the connected status icon instead.

1、当disableConnectingAnimation为true且存在多个网卡时，如果一个网卡已连接而另一个正在连接，图标会错误地显示断开状态。现在遍历所有网卡检查是否有已连接的，如有则显示已连接状态图标。 2、修复禁用通知不生效

Log: 禁用连接动画时显示已连接状态
PMS: Task-392929
Influence: 连接动画

## Summary by Sourcery

Adjust network status handling to correctly reflect connected state when connecting animations are disabled and ensure notification-disable configuration is honored.

Bug Fixes:
- Ensure the dock shows a connected icon when at least one NIC is connected while others are in a transient connecting state and connecting animation is disabled.
- Respect the `disableAllNotify` configuration flag when loading notification-related settings.