### PR TITLE
feat: remove network-manager-integration-plugins dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,7 +44,16 @@ Description: the interface of networkcode,used for developers
 
 Package: dcc-network-plugin
 Architecture: any
-Depends: ${misc:Depends},${shlibs:Depends},network-manager-integration-plugins,libdde-network-core (= ${binary:Version})
+Depends: ${misc:Depends},
+        ${shlibs:Depends},
+        network-manager-openvpn,
+        network-manager-l2tp,
+        network-manager-pptp,
+        network-manager-vpnc,
+        network-manager-openconnect,
+        network-manager-strongswan | libreswan (>=4.12),
+        network-manager-sstp,
+        libdde-network-core (= ${binary:Version})
 Description: the plugin of network for dde control center
  dcc-network-plugin module
 


### PR DESCRIPTION
1. Replace network-manager-integration-plugins metapackage with its 7 direct NM plugin dependencies in dcc-network-plugin
2. This eliminates indirect libwebkit2gtk-4.1-0 dependency chain pulled in by network-manager-openconnect-gnome
3. DDE has its own VPN GUI, so GNOME VPN config plugins are intentionally excluded

PMS: TASK-393359

Influence:
1. Verify dcc-network-plugin installs without network-manager-integration-plugins
2. Verify VPN functionality works in control center after upgrade

feat: 移除 network-manager-integration-plugins 依赖

1. 将 dcc-network-plugin 的 network-manager-integration-plugins metapackage 依赖替换为 7 个具体的 NM 插件依赖
2. 消除由 network-manager-openconnect-gnome 间接引入的 libwebkit2gtk-4.1-0 依赖链
3. DDE 有自己的 VPN GUI，因此有意排除 GNOME VPN 配置插件

PMS: TASK-393359

Influence:
1. 验证 dcc-network-plugin 在不安装 network-manager-integration-plugins 时可正常安装
2. 验证升级后控制中心 VPN 功能正常

## Summary by Sourcery

Adjust Debian package dependencies for dcc-network-plugin to drop the network-manager-integration-plugins metapackage in favor of explicit NM plugin dependencies and avoid the unwanted libwebkit2gtk-4.1-0 chain.

Build:
- Replace the network-manager-integration-plugins metapackage dependency with a set of direct NetworkManager VPN plugin dependencies in debian/control.
- Exclude GNOME VPN configuration plugins from dcc-network-plugin dependencies, relying on DDE’s own VPN GUI instead.