### PR TITLE
fix(network): avoid use-after-free of addrinfo hints in getaddrinfo w…

### DIFF
--- a/network-service-plugin/src/utils/httpmanager.cpp
+++ b/network-service-plugin/src/utils/httpmanager.cpp
@@ -26,7 +26,7 @@ namespace {
 struct GetAddrInfoParams {
     std::string node;
     std::string service;
-    const addrinfo *hints;
+    addrinfo hints;
     addrinfo *result = nullptr;
     int ret = 0;
     std::atomic<bool> delete_by_thread{false};
@@ -35,7 +35,7 @@ struct GetAddrInfoParams {
 static void *getaddrinfo_thread(void *arg)
 {
     GetAddrInfoParams *params = static_cast<GetAddrInfoParams *>(arg);
-    params->ret = getaddrinfo(params->node.c_str(), params->service.c_str(), params->hints, &params->result);
+    params->ret = getaddrinfo(params->node.c_str(), params->service.c_str(), &params->hints, &params->result);
     // deleteByThread 为 true 说明主线程已 detach，由本线程释放 params
     if (params->delete_by_thread.load())
         delete params;
@@ -49,7 +49,8 @@ static int getaddrinfo_with_timeout(const std::string &node, const std::string &
                                     int timeoutMs)
 {
     // 在堆上分配 params，防止 detach 的线程在超时后写入已释放的栈内存
-    GetAddrInfoParams *params = new GetAddrInfoParams{node, service, hints, nullptr, 0};
+    // hints 也按值拷贝，避免超时分支里调用方栈上的 addrinfo 失效后被子线程解引用
+    GetAddrInfoParams *params = new GetAddrInfoParams{node, service, hints ? *hints : addrinfo{}, nullptr, 0};
     pthread_t thread;
     pthread_attr_t attr;
     pthread_attr_init(&attr);


### PR DESCRIPTION
…orker thread

In HttpManager::get, the stack-local `addrinfo hints` was passed by pointer into getaddrinfo_with_timeout and stored in the heap-allocated GetAddrInfoParams. When pthread_timedjoin_np timed out, the caller detached the worker thread and returned, destroying the stack frame that held `hints`. The detached worker then dereferenced the dangling `hints` pointer inside getaddrinfo, raising SIGSEGV (reproduced in deepin-service-manager core dumps on LoongArch, with getaddrinfo called with hints=0x16).

Store `hints` by value in GetAddrInfoParams and copy it when constructing the params, so the worker thread no longer depends on the caller's stack lifetime. This mirrors the existing fix that turned node/service into owning std::string members, closing the last remaining dangling pointer in this async path.

在 HttpManager::get 中，栈上的 `addrinfo hints` 以指针形式传入
getaddrinfo_with_timeout 并存入堆上的 GetAddrInfoParams。当 pthread_timedjoin_np 超时后，调用方 detach 工作线程并返回，存放 `hints` 的 栈帧被销毁，被 detach 的工作线程随后在 getaddrinfo 中解引用悬空的 `hints` 指针导致 SIGSEGV（该问题在 LoongArch 上 deepin-service-manager 的 coredump 中复现，getaddrinfo 以 hints=0x16 被调用）。

将 `hints` 在 GetAddrInfoParams 中改为按值持有，并在构造 params 时拷贝，使 工作线程不再依赖调用方栈的生命周期。这与此前把 node/service 改为持有数据的
std::string 成员的修复方式一致，消除了该异步路径中最后一个悬空指针。

PMS: BUG-369359

## Summary by Sourcery

Bug Fixes:
- Ensure GetAddrInfoParams owns a copy of addrinfo hints so worker threads no longer reference stack-local hints after timeouts.