### PR TITLE
fix(network): don't check network

### DIFF
--- a/config/org.deepin.dde.network.json
+++ b/config/org.deepin.dde.network.json
@@ -340,7 +340,7 @@
             "visibility":"private"
          },
          "needCheckNetwork":{
-            "value":true,
+            "value":false,
             "serial":0,
             "flags":["global"],
             "name":"needCheckNetwork",


### PR DESCRIPTION
在设置一个不可用的代理或者错误的dns的情况下，本地检测网络会失败，会断开当前的网络并且去连接其他的网卡，导致频繁断开重连

PMS: BUG-372223

## Summary by Sourcery

Bug Fixes:
- Avoid frequent disconnect/reconnect cycles caused by network checks failing under invalid proxy or DNS settings.