### PR TITLE
fix(net-view): fix ghosting of two checkmarks when hovering connected items

### DIFF
--- a/net-view/window/netview.cpp
+++ b/net-view/window/netview.cpp
@@ -131,6 +131,8 @@ void NetView::rowsInserted(const QModelIndex &parent, int start, int end)
             indexes.append(m->index(j, 0, i));
         }
     }
+    // 编辑器控件重建后同步当前悬停行的状态，否则悬停行会短暂显示为未悬停状态
+    syncCurrentHoverState();
     QTreeView::rowsInserted(parent, start, end);
 
     QModelIndex newIndex = m->index(start, 0, parent);
@@ -413,6 +415,18 @@ void NetView::horizontalScrollbarValueChanged(int)
 void NetView::currentChanged(const QModelIndex &current, const QModelIndex &previous)
 {
     QTreeView::currentChanged(current, previous);
+    // 悬停状态由事件（HoverMove/HoverLeave/滚动/点击）驱动更新，
+    // 避免在 delegate 的 paint() 中修改控件可见性导致重入式重绘而产生重影
+    if (previous.isValid()) {
+        if (auto *itemWidget = qobject_cast<NetItemWidget *>(indexWidget(previous))) {
+            itemWidget->setHover(false);
+        }
+    }
+    if (current.isValid()) {
+        if (auto *itemWidget = qobject_cast<NetItemWidget *>(indexWidget(current))) {
+            itemWidget->setHover(true);
+        }
+    }
     if (previous.isValid()) {
         QRect rect = visualRect(previous);
         rect.setRect(0, rect.y() - 1, viewport()->width(), rect.height() + 2);
@@ -424,6 +438,17 @@ void NetView::currentChanged(const QModelIndex &current, const QModelIndex &prev
         viewport()->update(rect);
     }
     m_updateCurrent = false;
+}
+
+void NetView::syncCurrentHoverState()
+{
+    const QModelIndex current = currentIndex();
+    if (!current.isValid())
+        return;
+
+    if (auto *itemWidget = qobject_cast<NetItemWidget *>(indexWidget(current))) {
+        itemWidget->setHover(true);
+    }
 }
 
 void NetView::updateGeometries()

--- a/net-view/window/netview.h
+++ b/net-view/window/netview.h
@@ -65,6 +65,7 @@ protected Q_SLOTS:
 
 private:
     QModelIndex traverseAndSearch(const QModelIndex &parent, const QString &id);
+    void syncCurrentHoverState();
 
 private:
     NetManager *m_manager;

--- a/net-view/window/private/netdelegate.cpp
+++ b/net-view/window/private/netdelegate.cpp
@@ -171,19 +171,11 @@ void NetDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, c
             } else {
                 textColor = boption.dpalette.highlightedText().color();
                 bgColor = boption.dpalette.highlight().color();
-                NetItemWidget *itemWidget = qobject_cast<NetItemWidget *>(m_view->indexWidget(index));
-                if (itemWidget) {
-                    itemWidget->setHover(true);
-                }
             }
         } else {
             textColor = boption.dpalette.brightText().color();
             bgColor = boption.dpalette.brightText().color();
             bgColor.setAlphaF(0.05);
-            NetItemWidget *itemWidget = qobject_cast<NetItemWidget *>(m_view->indexWidget(index));
-            if (itemWidget) {
-                itemWidget->setHover(false);
-            }
         }
     } break;
     default:


### PR DESCRIPTION
When a connected item is hovered, the delegate's paint() used to call setHover(), which toggled widget visibility (m_connBut/m_disconnectBtn) inside the viewport paint pass. That triggered re-entrant layout and repaint of the persistent editor row, so for a frame the stale checkmark and the newly shown disconnect button were composited together, flashing two checkmarks. Move hover state updates out of paint() into NetView::currentChanged, which is driven by mouse events (HoverMove/HoverLeave/scroll/click), and re-sync the hover state in rowsInserted after row editors are recreated.

Log: fix the double checkmark ghosting when hovering connected network items
Influence: fixes hover rendering on the network list of lock screen and dock

修复：已连接的网络项悬停时，delegate 的 paint() 会在视口绘制过程中调用
setHover() 切换控件可见性（m_connBut/m_disconnectBtn），导致行的持久编辑器 被重入式地重新布局和重绘，一帧内旧的对勾残留与新显示的断开按钮叠加渲染，
闪现两个对勾。现将悬停状态更新从 paint() 移出到由鼠标事件
（HoverMove/HoverLeave/滚动/点击）驱动的 NetView::currentChanged 中，并在 rowsInserted 重建行编辑器后同步恢复悬停状态。

Log: 修复已连接网络项悬停时闪现两个对勾的重影问题
Influence: 修复锁屏与任务栏网络列表的悬停渲染
PMS: BUG-372167

## Summary by Sourcery

Adjust hover state management for network list items to prevent visual artifacts when hovering connected entries.

Bug Fixes:
- Fix double checkmark ghosting when hovering connected network items in the lock screen and dock network lists.

Enhancements:
- Drive item hover state from view selection and row lifecycle instead of delegate painting to avoid re-entrant layout and repaint issues.