### PR TITLE
fix: fix crash in control center network module

### DIFF
--- a/net-view/operation/private/netmanagerthreadprivate.cpp
+++ b/net-view/operation/private/netmanagerthreadprivate.cpp
@@ -37,6 +37,7 @@
 #include <impl/vpncontroller.h>
 #include <proxycontroller.h>
 
+#include <QCoreApplication>
 #include <QDBusConnection>
 #include <QProcess>
 #include <QThread>
@@ -87,7 +88,7 @@ const QString notifyIconMobileUnknownDisconnected = "notification-network-mobile
 NetManagerThreadPrivate::NetManagerThreadPrivate()
     : QObject()
     , m_thread(new QThread(this))
-    , m_parentThread(QThread::currentThread())
+    , m_parentThread(qApp->thread())
     , m_isInitialized(false)
     , m_enabled(true)
     , m_autoScanInterval(0)
@@ -124,7 +125,7 @@ NetManagerThreadPrivate::~NetManagerThreadPrivate()
                                                 this,
                                                 SLOT(onPortalDetected(const QString &)));
     }
-    
+
     if (m_flags.testFlags(NetType::NetManagerFlag::Net_Airplane)) {
         QDBusConnection::systemBus().disconnect("org.deepin.dde.Bluetooth1", "/org/deepin/dde/Bluetooth1", "org.deepin.dde.Bluetooth1", "AdapterAdded", this, SLOT(getAirplaneModeEnabled()));
         QDBusConnection::systemBus().disconnect("org.deepin.dde.Bluetooth1", "/org/deepin/dde/Bluetooth1", "org.deepin.dde.Bluetooth1", "AdapterRemoved", this, SLOT(getAirplaneModeEnabled()));


### PR DESCRIPTION
1. Replace QThread::currentThread() with qApp->thread() for m_parentThread initialization in NetManagerThreadPrivate constructor
2. qApp->thread() explicitly references the main/UI thread, avoiding potential ambiguity if the constructor is ever called from a non-main thread
3. Add missing #include <QCoreApplication> required for qApp->thread() call

Log: Fixes SIGSEGV crash in dde-control-center when network plugin initializes on a worker thread

Influence:
1. Confirm network control panel opens and displays correctly

fix: 修改控制中心网络模块崩溃问题

1. 将 NetManagerThreadPrivate 构造函数中 m_parentThread 的初始化从 QThread::currentThread() 改为 qApp->thread()
2. qApp->thread() 显式引用主线程/UI 线程，避免构造函数 在非主线程调用时产生歧义
3. 添加缺失的 #include <QCoreApplication> 头文件

Log: 修复 dde-control-center 加载网络插件时的 SIGSEGV
崩溃

Influence:
1. 确认网络控制面板正常打开和显示

PMS: TASK-390967

## Summary by Sourcery

Ensure the network control panel initializes its worker thread using the main application thread to avoid crashes when loaded from non-main threads.

Bug Fixes:
- Prevent SIGSEGV crashes in the control center when the network plugin is initialized from a worker thread.

Enhancements:
- Clarify parent thread association for NetManagerThreadPrivate by explicitly referencing the UI thread via the application object.