### PR TITLE
fix(hotspot): optimize hotspot switch sync latency

### DIFF
--- a/dcc-network/qml/PageHotspot.qml
+++ b/dcc-network/qml/PageHotspot.qml
@@ -20,6 +20,13 @@ DccObject {
     property var config: null
     property bool isAirplane: false
     property string interfaceName: ""
+    enum Status {
+        Disabling,
+        Enabling,
+        Disabled,
+        Enabled
+    }
+    property int hotspotStatus: (netItem && netItem.isEnabled) ? PageHotspot.Status.Enabled : PageHotspot.Status.Disabled
 
     function setNetItem(item) {
         if (netItem !== item) {
@@ -95,10 +102,11 @@ DccObject {
             D.Switch {
                 id: switchControl
                 anchors.fill: parent
-                checked: netItem.isEnabled
-                enabled: netItem.enabledable && !isAirplane && netItem.deviceEnabled
+                checked: root.hotspotStatus === PageHotspot.Status.Enabled || root.hotspotStatus === PageHotspot.Status.Enabling
+                enabled: netItem.enabledable && !isAirplane && netItem.deviceEnabled && root.hotspotStatus !== PageHotspot.Status.Enabling && root.hotspotStatus !== PageHotspot.Status.Disabling
                 onClicked: {
                     if (checked) {
+                        root.hotspotStatus = PageHotspot.Status.Enabling
                         if (config["connection"]["uuid"] === "{00000000-0000-0000-0000-000000000000}") {
                             dccData.exec(NetManager.SetConnectInfo, netItem.id, config)
                         } else {
@@ -107,6 +115,7 @@ DccObject {
                                          })
                         }
                     } else {
+                        root.hotspotStatus = PageHotspot.Status.Disabling
                         dccData.exec(NetManager.Disconnect, netItem.id, {
                                          "uuid": config["connection"]["uuid"]
                                      })
@@ -120,6 +129,9 @@ DccObject {
         function onConfigChanged(config) {
             root.config = config
             updateDevModel()
+        }
+        function onIsEnabledChanged() {
+            root.hotspotStatus = netItem.isEnabled ? PageHotspot.Status.Enabled : PageHotspot.Status.Disabled
         }
     }
 


### PR DESCRIPTION
1. Add Status enum (Disabling, Enabling, Disabled, Enabled) to
   track hotspot state independently from backend
2. Use optimistic update: set Enabling/Disabling on click,
   revert to Enabled/Disabled when onIsEnabledChanged fires
3. This eliminates the visible delay when navigating between
   secondary and tertiary hotspot pages

Log: Hotspot switch state syncs instantly on page navigation

PMS: BUG-298043
Influence:
1. Toggle hotspot on secondary page, enter tertiary page and
   back, verify switch reflects the clicked state immediately
2. Toggle hotspot on tertiary page, return to secondary page,
   verify switch state is consistent

fix(hotspot): 优化个人热点开关状态同步延迟

1. 新增 Status 枚举（Disabling, Enabling, Disabled, Enabled），
   独立于后端跟踪热点状态
2. 采用乐观更新策略：点击时设置 Enabling/Disabling，
   收到 onIsEnabledChanged 后回归 Enabled/Disabled
3. 消除二级页面和三级页面切换时开关状态同步的可感知延迟

Log: 个人热点开关状态在页面切换时即时同步

PMS: BUG-298043
Influence:
1. 在二级页面开关热点，进入三级页面后返回，验证开关立即反映点击状态
2. 在三级页面开关热点，返回二级页面，验证开关状态一致

## Summary by Sourcery

Optimize hotspot toggle state synchronization latency between hotspot pages.

Bug Fixes:
- Ensure hotspot switch state stays consistent and instantly reflected when navigating between secondary and tertiary hotspot pages.
- Fix potential threading issues by binding NetManagerThreadPrivate parent thread to the application main thread instead of the constructing thread.

Enhancements:
- Introduce a hotspot status enum and optimistic UI updates so the hotspot toggle reflects user actions immediately while awaiting backend confirmation.