### PR TITLE
fix: update Accounts D-Bus interface names to org.deepin.dde.Accounts1

### DIFF
--- a/network-service-plugin/src/system/networkinitialization.cpp
+++ b/network-service-plugin/src/system/networkinitialization.cpp
@@ -303,11 +303,11 @@ QVariant NetworkInitialization::accountInterface(const QString &path, const QStr
 {
     QString interfaceName;
     if (isUser) {
-        interfaceName = "com.deepin.daemon.Accounts.User";
+        interfaceName = "org.deepin.dde.Accounts1.User";
     } else {
-        interfaceName = "com.deepin.daemon.Accounts";
+        interfaceName = "org.deepin.dde.Accounts1";
     }
-    QDBusInterface dbus("com.deepin.daemon.Accounts", path, interfaceName, QDBusConnection::systemBus());
+    QDBusInterface dbus("org.deepin.dde.Accounts1", path, interfaceName, QDBusConnection::systemBus());
     return dbus.property(key.toLocal8Bit().constData());
 }
 


### PR DESCRIPTION
1. Replace com.deepin.daemon.Accounts with org.deepin.dde.Accounts1 in accountInterface() for both service name and interface names
2. Ensures D-Bus calls match the renamed account service on V25, preventing lookup failures during rollback/boot procedures

PMS: BUG-373169

Log: update Accounts D-Bus interface names to org.deepin.dde.Accounts1

Influence:
1. 升级系统后执行回退流程，验证能否正常进入桌面
2. 控制中心-系统-启动菜单-启动设置中选择回退并重启，验证系统正常启动

fix: 更新 Accounts D-Bus 接口名为 org.deepin.dde.Accounts1

1. 将 accountInterface() 中的 com.deepin.daemon.Accounts 替换为 org.deepin.dde.Accounts1，同步更新服务名和接口名
2. 确保 D-Bus 调用与 V25 上重命名后的账户服务一致， 避免回退/启动过程中查找失败

PMS: BUG-373169

Log: 更新 Accounts D-Bus 接口名为 org.deepin.dde.Accounts1

Influence:
1. 升级系统后执行回退流程，验证能否正常进入桌面
2. 控制中心-系统-启动菜单-启动设置中选择回退并重启，验证系统正常启动

## Summary by Sourcery

Bug Fixes:
- Align network initialization D-Bus calls with the renamed Accounts service to prevent lookup failures during rollback and boot flows.